### PR TITLE
Fix biomass flux

### DIFF
--- a/shamba/model/tree_model.py
+++ b/shamba/model/tree_model.py
@@ -417,7 +417,7 @@ def get_inputs(
         "DMon": 0.001 * CONSTANTS.TREE_ROOT_IN_TOP_30 * (DM[:, 3] + DM[:, 4]),
         "DMoff": np.zeros(len(C[:, 0])),
     }
-    print(stand_density)
+    
     return output, stand_biomass, mass_balance
 
 


### PR DESCRIPTION
Recent changes to biomass flux calculations had unintended consequences, e.g. to the mass balance calculation.

This PR ensures that tree carbon mass balance holds. It also changes flux to be 'within year' for tree biomass.