### PR TITLE
Expand testing coverage

### DIFF
--- a/shamba/tests/TEST_COVERAGE.md
+++ b/shamba/tests/TEST_COVERAGE.md
@@ -1,0 +1,181 @@
+# Test coverage summary
+
+---
+
+## test_validation.py — data_handler.py validation functions
+
+### `validate_required_mgmt_keys()`
+| Test | Purpose |
+|------|---------|
+| `test_passes_when_all_required_keys_present` | All required keys present → no errors returned |
+| `test_error_names_missing_keys_in_single_message` | Multiple missing keys are grouped into one error message (not one error per key) |
+
+### `validate_species_data()`
+| Test | Purpose |
+|------|---------|
+| `test_passes_when_age_and_diam_present_for_declared_species` | Valid species with age + diameter data → no errors |
+| `test_error_when_size_data_missing_for_declared_species` | Declared species with no size data → errors naming the missing keys |
+| `test_no_false_positive_when_only_one_key_missing` | Only the actually missing key is reported; present keys are not flagged |
+
+### `resolve_evap_pet()`
+| Test | Purpose |
+|------|---------|
+| `test_evap_wins_and_pet_discarded_when_both_present` | When both evap and PET supplied, evap is used and PET is discarded |
+| `test_pet_converted_to_evap_via_open_pan_factor` | When only PET supplied, it is converted to evap via the open-pan factor (÷ 0.75) |
+| `test_raises_when_neither_evap_nor_pet_present` | Neither key present → ValueError raised |
+
+---
+
+## test_emit.py — emit.py building-block functions
+
+### `reduce_from_fire()`
+| Test | Purpose |
+|------|---------|
+| `test_no_fire_returns_unmodified_above_plus_below` | Zero fire → output = above + below carbon, unmodified |
+| `test_fire_reduces_crop_above_ground_by_combustion_factor` | Fire year reduces crop above-ground by the crop combustion factor (0.85); below-ground untouched |
+| `test_fire_reduces_tree_above_ground_by_tree_combustion_factor` | Fire year reduces tree above-ground by the tree combustion factor (0.74); below-ground untouched |
+| `test_empty_inputs_return_zeros` | No crop, tree, or litter inputs → zero output arrays |
+
+### `soc_sink()`
+| Test | Purpose |
+|------|---------|
+| `test_numeric_value_1_tC_increase` | 1 t C/ha increase → 44/12 t CO2/ha/yr (IPCC conversion factor) |
+| `test_constant_soc_returns_zero` | Constant SOC → zero sink/source |
+
+### `tree_sink()`
+| Test | Purpose |
+|------|---------|
+| `test_numeric_value` | Known biomass increment → correct CO2e delta (2 t C/ha/yr → 2 × 44/12) |
+| `test_multiple_trees_are_summed` | Multiple tree objects contribute additively to the total sink |
+
+### Zero-input smoke tests
+| Test | Purpose |
+|------|---------|
+| `test_fert_emit_zero_for_empty_inputs` | No fertiliser inputs → zero emissions |
+| `test_nitrogen_emit_zero_for_empty_inputs` | No nitrogen inputs → zero emissions |
+
+---
+
+## test_allometrics.py — tree_growth.py allometric and growth curve functions
+
+### Allometric equations
+| Test | Purpose |
+|------|---------|
+| `TestRyanAllometric::test_known_value_at_dbh_10` | Numeric spot-check of Ryan (2010) formula at DBH=10 against hand calculation |
+| `TestRyanAllometric::test_zero_dbh_returns_zero` | DBH=0 → AGB=0 (guard against log(0)) |
+| `TestChaveDryAllometric::test_known_value_at_dbh_10_wd_0p6_carbon_0p48` | Numeric spot-check of Chave dry (2005) formula at DBH=10, WD=0.6, carbon=0.48 |
+| `TestChaveDryAllometric::test_higher_wood_density_gives_higher_agb` | WD appears as a multiplicative factor; higher WD must give higher AGB |
+| `TestTumwebazeMarkhamiaAllometric::test_known_value_at_dbh_10_carbon_0p48` | Numeric spot-check of Tumwebaze Markhamia (2013) formula at DBH=10, carbon=0.48 |
+
+### Growth curve functions (Eqs. 6.1–6.4)
+| Test | Purpose |
+|------|---------|
+| `test_linear_function` | f(x) = a·x: correct value and zero at x=0 |
+| `test_exponential_1param_function` | f(x) = (1+a)^x − 1: zero at x=0; correct value at x=1, a=1 |
+| `test_hyperbolic_function` | f(x) = a·(1 − exp(−b·x)): zero at x=0; approaches asymptote a at large x |
+| `test_logistic_function` | f(x) = a/(1+exp(−b·(x−c))): equals a/2 at the inflection point x=c |
+| `test_fit_produces_monotonically_increasing_hyperbolic_curve` | Fitting to monotonically increasing data yields a monotonically increasing hyperbolic curve |
+
+### `TestFromCsvBiomassInput` — direct AGB input (bypasses allometrics)
+| Test | Purpose |
+|------|---------|
+| `test_uses_provided_biomass_directly` | When `biomass_sp<n>` is present, growth uses those values not the allometric equation |
+| `test_falls_back_to_allometry_when_biomass_not_provided` | Without biomass input, falls back to computing AGB from diameter via allometric key |
+| `test_provided_biomass_independent_of_allometric_key` | Changing allometric key has no effect on growth when biomass is supplied directly |
+| `test_age_and_biomass_only_no_diam` | `diam_sp<n>` may be absent when biomass is provided directly; no diameter stored |
+
+---
+
+## test_roth_c.py — RothC soil carbon model
+
+### `get_rmf()` — Rate Modifying Factor
+| Test | Purpose |
+|------|---------|
+| `test_rmf_equals_one_when_rain_always_exceeds_evap` | Always-wet climate triggers the short-circuit branch, returning b.mean()=1.0 for all years |
+| `test_severe_drought_gives_lower_rmf_than_mild_drought` | Larger moisture deficit → smaller b factor → lower RMF (tests the full moisture calculation path) |
+| `test_soil_cover_reduces_rmf_under_drought` | Soil cover applies c=0.6 instead of 1.0, reducing the RMF |
+
+### `inverse_roth_c.create()`
+| Test | Purpose |
+|------|---------|
+| `test_equilibrium_pools_sum_to_approximately_ceq` | Equilibrium pool totals (+ IOM) ≈ Ceq within 20% (coarse grid search tolerance) |
+| `test_equilibrium_pools_are_non_negative` | All four equilibrium pool values are ≥ 0 |
+
+### `forward_roth_c.create()`
+| Test | Purpose |
+|------|---------|
+| `test_soc_has_correct_shape` | Output SOC array is (n_years+1) × 4 pools |
+| `test_pools_do_not_go_substantially_negative` | ODE solver may undershoot near zero; no pool goes below −1e-6 t C/ha |
+| `test_inverse_forward_round_trip_is_stable` | Equilibrium pools from inverse solver fed into forward solver produce < 30% total carbon change over 10 years |
+| `test_forward_solver_numeric_regression` *(skipped)* | Exact pool values at year 5 to be confirmed against the official RothC Python reference repository before activation |
+
+---
+
+## test_crop_emissions.py — crop model emissions (baseline and project)
+
+### `test_crop_model()` — parametrized: WL, testB
+| Test case | Purpose |
+|-----------|---------|
+| WL | Constant single-crop baseline (all years equal); project switches to zero emissions after year 4 (crop removed) |
+| testB | Mixed-crop baseline with two crop types across different year ranges; project has irregular non-zero windows from changing crop schedules |
+
+Both cases call `get_crop_bases` / `get_crop_projects`, then `Emit.create(crop=..., fire=..., burn_off=...)` and assert against hardcoded per-year emission arrays (rel tolerance 1e-4).
+
+---
+
+## test_fertiliser_emissions.py — synthetic fertiliser emissions (baseline and project)
+
+### `test_fertiliser_model()` — parametrized: WL, testB
+| Test case | Purpose |
+|-----------|---------|
+| WL | No fertiliser in either baseline or project — all-zero expected arrays confirm no spurious emissions |
+| testB | Periodic fertiliser applications in project only; expected array has non-zero values at each application year |
+
+Calls `LitterModel.synthetic_fertiliser(frequency, quantity, nitrogen, no_of_years)`, then `Emit.create(fert=..., fire=..., burn_off=...)` and asserts against hardcoded per-year arrays (rel tolerance 1e-4).
+
+---
+
+## test_fire_emissions.py — fire (burn-off) emissions from crops
+
+### `test_crop_fire_model()` — parametrized: WL, testB
+| Test case | Purpose |
+|-----------|---------|
+| WL | No fire in either scenario — all-zero arrays confirm `fire_emit` is inert when fire is absent |
+| testB | Project has fire events; expected arrays show non-zero fire emissions only at the scheduled fire years |
+
+Calls `Emit.fire_emit(fire=..., crop=..., tree=[], litter=[], burn_off=..., gwp=GWP_AR6)` and asserts per-year arrays (rel tolerance 1e-5).
+
+---
+
+## test_litter_emissions.py — external litter input emissions (baseline and project)
+
+### `test_litter_model()` — parametrized: WL, testB
+| Test case | Purpose |
+|-----------|---------|
+| WL | No litter inputs in either scenario — all-zero arrays confirm no spurious emissions |
+| testB | Periodic litter applications; baseline and project expected arrays show non-zero values at each litter application year, with project year-0 higher due to additional litter type |
+
+Calls `LitterModel.from_defaults(litter_frequency, litter_quantity, no_of_years)`, then `Emit.create(litter=..., fire=..., burn_off=...)` and asserts per-year arrays (rel tolerance 1e-5).
+
+---
+
+## test_tree_emissions.py — tree model emissions (baseline and project)
+
+### `test_tree_model()` — parametrized: WL, testB
+| Test case | Purpose |
+|-----------|---------|
+| WL | Baseline has no trees (all zeros); project shows a carbon sink building over time with positive spikes at thinning/harvest events |
+| testB | Baseline has a single pre-existing tree cohort (small but non-zero sink); project has multiple cohorts with staggered planting — irregular per-year sink values reflecting growth curves, thinning, and mortality |
+
+Constructs tree objects via `TreeParams`, `TreeGrowth.get_growth` / `create_tree_growths`, `TreeModel.from_defaults` / `create_tree_projects`, then calls `Emit.create(tree=..., fire=..., burn_off=...)`. Asserts per-year arrays with relaxed tolerance (rel=1e-3) because expected values depend on curve-fitting results that may differ slightly from Excel reference calculations.
+
+---
+
+## test_integration_split_file.py — split-file CSV input path
+
+| Test | Purpose |
+|------|---------|
+| `test_split_file_data_pipeline_matches_single_row` | Reading the three split-file CSVs (plot, mgmt, tree_size, climate_cover) produces a dict with identical keys and values to `expand_single_row_data_input` for the same scenario |
+| `test_split_file_full_run_matches_single_row` | `handle_intervention` returns numerically identical baseline and project emissions for both input paths (rtol=1e-10) |
+
+Fixtures are generated programmatically from `WL_input.csv`; no manually maintained split-file fixtures.

--- a/shamba/tests/test_allometrics.py
+++ b/shamba/tests/test_allometrics.py
@@ -1,0 +1,186 @@
+"""Tests for allometric equations and growth curve functions in tree_growth.py.
+
+Expected values are computed by hand from the published formulae:
+  - Ryan (2010): ln(AGB) = 2.601*ln(DBH) - 3.629
+  - Chave et al. (2005): ln(AGB) = polyval(params, ln(DBH)), then * wood_density * carbon
+  - Tumwebaze et al. (2013): sum of two log-allometric terms * carbon
+  - Growth curve functions: directly from model description equations 6.1–6.4
+"""
+
+import math
+import types
+
+import numpy as np
+import pytest
+
+import model.tree_growth as TreeGrowth
+
+
+def _make_tree_params(wood_dens=0.6, carbon=0.48):
+    """Return a minimal mock object with the attributes allometric functions use."""
+    return types.SimpleNamespace(wood_dens=wood_dens, carbon=carbon)
+
+
+class TestRyanAllometric:
+    """C. Ryan, biotropica (2010): AGB = exp(2.601*ln(DBH) - 3.629), units kg C"""
+
+    def test_known_value_at_dbh_10(self):
+        # Hand calculation:
+        #   ln(10) = 2.302585
+        #   log_biomass = 2.601 * 2.302585 - 3.629 = 5.989024 - 3.629 = 2.360024
+        #   AGB = exp(2.360024) ≈ 10.591 kg C
+        tp = _make_tree_params()
+        result = TreeGrowth.ryan(dbh=10.0, tree_params=tp)
+        expected = math.exp(2.601 * math.log(10.0) - 3.629)
+        assert result == pytest.approx(expected, rel=1e-6)
+        assert result == pytest.approx(10.591, rel=1e-3)
+
+    def test_zero_dbh_returns_zero(self):
+        assert TreeGrowth.ryan(dbh=0.0, tree_params=_make_tree_params()) == 0.0
+
+
+class TestChaveDryAllometric:
+    """Chave et al. (2005) dry forest.
+
+    Formula: AGB = exp(polyval([-0.0281, 0.207, 1.784, -0.730], ln(DBH))) * WD * carbon
+    """
+
+    def test_known_value_at_dbh_10_wd_0p6_carbon_0p48(self):
+        # Hand calculation:
+        #   ln(10) = 2.302585
+        #   polyval([-0.0281, 0.207, 1.784, -0.730], 2.302585)
+        #     = -0.0281*(2.302585)^3 + 0.207*(2.302585)^2 + 1.784*(2.302585) - 0.730
+        #     ≈ -0.342947 + 1.097493 + 4.107832 - 0.730000 = 4.132378
+        #   raw_agb = exp(4.132378) ≈ 62.326
+        #   AGB = 62.326 * 0.6 * 0.48 ≈ 17.950 kg C
+        tp = _make_tree_params(wood_dens=0.6, carbon=0.48)
+        result = TreeGrowth.chave_dry(dbh=10.0, tree_params=tp)
+        log10 = math.log(10.0)
+        log_raw_agb = np.polyval([-0.0281, 0.207, 1.784, -0.730], log10)
+        expected = math.exp(log_raw_agb) * 0.6 * 0.48
+        assert result == pytest.approx(expected, rel=1e-6)
+        assert result == pytest.approx(17.950, rel=1e-2)
+
+    def test_higher_wood_density_gives_higher_agb(self):
+        assert (
+            TreeGrowth.chave_dry(10.0, _make_tree_params(wood_dens=0.8))
+            > TreeGrowth.chave_dry(10.0, _make_tree_params(wood_dens=0.4))
+        )
+
+
+class TestTumwebazeMarkhamiaAllometric:
+    """Tumwebaze et al. (2013) Markhamia.
+
+    Formula: AGB = (exp(polyval([2.63, -4.91], ln(DBH)))
+                  + exp(polyval([2.43, -3.08], ln(DBH)))) * carbon
+    """
+
+    def test_known_value_at_dbh_10_carbon_0p48(self):
+        # Hand calculation:
+        #   ln(10) = 2.302585
+        #   term1 = exp(2.63*2.302585 - 4.91) = exp(6.055799 - 4.91) = exp(1.145799) ≈ 3.145
+        #   term2 = exp(2.43*2.302585 - 3.08) = exp(5.595282 - 3.08) = exp(2.515282) ≈ 12.370
+        #   AGB = (3.145 + 12.370) * 0.48 ≈ 7.447 kg C
+        tp = _make_tree_params(carbon=0.48)
+        result = TreeGrowth.tumwebaze_markhamia(dbh=10.0, tree_params=tp)
+        log10 = math.log(10.0)
+        term1 = math.exp(np.polyval([2.63, -4.91], log10))
+        term2 = math.exp(np.polyval([2.43, -3.08], log10))
+        expected = (term1 + term2) * 0.48
+        assert result == pytest.approx(expected, rel=1e-6)
+        assert result == pytest.approx(7.447, rel=1e-2)
+
+
+class TestGrowthCurveFunctions:
+    """Tests for the standalone growth curve functions (Eqs. 6.1–6.4 in model description)."""
+
+    def test_linear_function(self):
+        # Eq. 6.1: f(x) = a*x
+        assert TreeGrowth.linear_function(5.0, 2.0) == pytest.approx(10.0)
+        assert TreeGrowth.linear_function(0.0, 2.0) == 0.0
+
+    def test_exponential_1param_function(self):
+        # Eq. 6.2: f(x) = (1+a)^x - 1
+        # At x=0: f=0; at x=1, a=1: f=(1+1)^1 - 1 = 1
+        assert TreeGrowth.exponential_1param_function(0.0, 0.5) == pytest.approx(0.0)
+        assert TreeGrowth.exponential_1param_function(1.0, 1.0) == pytest.approx(1.0)
+
+    def test_hyperbolic_function(self):
+        # Eq. 6.3: f(x) = a*(1 - exp(-b*x))
+        # At x→∞: f→a; at x=0: f=0
+        a, b = 100.0, 0.5
+        assert TreeGrowth.hyperbolic_function(0.0, a, b) == pytest.approx(0.0)
+        # At large x, approaches asymptote a
+        assert TreeGrowth.hyperbolic_function(100.0, a, b) == pytest.approx(a, rel=1e-5)
+
+    def test_logistic_function(self):
+        # Eq. 6.4: f(x) = a / (1 + exp(-b*(x-c)))
+        # At x=c: f = a/2 (inflection point)
+        a, b, c = 100.0, 0.5, 10.0
+        assert TreeGrowth.logistic_function(c, a, b, c) == pytest.approx(a / 2.0)
+
+    def test_fit_produces_monotonically_increasing_hyperbolic_curve(self):
+        # On monotonically increasing training data, the fitted hyperbolic curve
+        # should also be monotonically increasing.
+        age = np.array([1.0, 2.0, 5.0, 10.0, 20.0])
+        biomass = np.array([0.5, 1.2, 4.0, 10.0, 22.0])
+        all_fit_data, all_fit_params, _ = TreeGrowth.fit(age, biomass)
+        ages_fine = np.linspace(1, 20, 100)
+        curve = TreeGrowth.hyperbolic_function(ages_fine, *all_fit_params["hyp"])
+        assert all(np.diff(curve) > 0)
+
+
+class TestFromCsvBiomassInput:
+    """Tests that from_csv uses directly provided biomass data when available,
+    bypassing the allometric equation."""
+
+    def _make_tree_params(self):
+        return types.SimpleNamespace(wood_dens=0.6, carbon=0.48, root_to_shoot=0.26, nitrogen=0.01)
+
+    def _base_input(self):
+        return {
+            "age_sp1": np.array([1.0, 2.0, 5.0, 10.0]),
+            "diam_sp1": np.array([5.0, 8.0, 12.0, 18.0]),
+        }
+
+    def test_uses_provided_biomass_directly(self):
+        # Biomass values chosen to be inconsistent with any allometric equation —
+        # if the model computes from diameter instead, this test will fail.
+        biomass = np.array([10.0, 25.0, 80.0, 200.0])
+        input_data = {**self._base_input(), "biomass_sp1": biomass}
+
+        growth = TreeGrowth.from_csv(self._make_tree_params(), "chave dry", input_data, sp_index=1)
+
+        np.testing.assert_array_equal(growth.biomass, biomass)
+
+    def test_falls_back_to_allometry_when_biomass_not_provided(self):
+        input_data = self._base_input()
+        tp = self._make_tree_params()
+
+        growth = TreeGrowth.from_csv(tp, "chave dry", input_data, sp_index=1)
+
+        expected = TreeGrowth.get_biomass(input_data["diam_sp1"], "chave dry", tp)
+        np.testing.assert_array_almost_equal(growth.biomass, expected)
+
+    def test_provided_biomass_independent_of_allometric_key(self):
+        # When biomass is supplied directly, changing the allometric key must not
+        # change the biomass used for fitting.
+        biomass = np.array([10.0, 25.0, 80.0, 200.0])
+        input_data = {**self._base_input(), "biomass_sp1": biomass}
+        tp = self._make_tree_params()
+
+        growth_dry = TreeGrowth.from_csv(tp, "chave dry", input_data, sp_index=1)
+        growth_ryan = TreeGrowth.from_csv(tp, "ryan", input_data, sp_index=1)
+
+        np.testing.assert_array_equal(growth_dry.biomass, growth_ryan.biomass)
+
+    def test_age_and_biomass_only_no_diam(self):
+        # diam_sp1 absent: valid when biomass_sp1 is present.
+        age = np.array([1.0, 2.0, 5.0, 10.0])
+        biomass = np.array([10.0, 25.0, 80.0, 200.0])
+        input_data = {"age_sp1": age, "biomass_sp1": biomass}
+
+        growth = TreeGrowth.from_csv(self._make_tree_params(), "chave dry", input_data, sp_index=1)
+
+        np.testing.assert_array_equal(growth.biomass, biomass)
+        assert len(growth.tree_diameter) == 0

--- a/shamba/tests/test_emit.py
+++ b/shamba/tests/test_emit.py
@@ -1,0 +1,135 @@
+"""Tests for individual functions in emit.py.
+
+These tests exercise the building-block functions (reduce_from_fire, soc_sink,
+tree_sink, nitrogen_emit, fert_emit) independently of the full model run.
+"""
+
+import types
+
+import numpy as np
+import pytest
+
+import model.emit as Emit
+from model.common.constants import (
+    C_to_CO2_conversion_factor,
+    combustion_factor,
+    GWP_list,
+    DEFAULT_GWP,
+)
+
+GWP = GWP_list[DEFAULT_GWP]
+
+
+def _make_biomass_model(n_years, above_carbon, below_carbon):
+    """Create a minimal mock biomass object with the .output structure that
+    reduce_from_fire, nitrogen_emit, and fert_emit read from."""
+    obj = types.SimpleNamespace()
+    obj.output = {
+        "above": {
+            "carbon": np.array(above_carbon, dtype=float),
+            "nitrogen": np.zeros(n_years),
+            "DMon": np.zeros(n_years),
+            "DMoff": np.zeros(n_years),
+        },
+        "below": {
+            "carbon": np.array(below_carbon, dtype=float),
+            "nitrogen": np.zeros(n_years),
+            "DMon": np.zeros(n_years),
+            "DMoff": np.zeros(n_years),
+        },
+    }
+    return obj
+
+
+class TestReduceFromFire:
+
+    def test_no_fire_returns_unmodified_above_plus_below(self):
+        # fire=0 every year → output equals sum of above + below carbon inputs.
+        n = 3
+        crop = [_make_biomass_model(n, [10.0, 10.0, 10.0], [5.0, 5.0, 5.0])]
+        fire = np.zeros(n)
+        crop_out, _ = Emit.reduce_from_fire(n, crop=crop, fire=fire)
+        np.testing.assert_allclose(crop_out, [15.0, 15.0, 15.0])
+
+    def test_fire_reduces_crop_above_ground_by_combustion_factor(self):
+        # combustion_factor["crop"] = 0.85
+        # After fire: above = above * (1 - 0.85) = above * 0.15
+        n = 3
+        crop = [_make_biomass_model(n, [10.0, 10.0, 10.0], [5.0, 5.0, 5.0])]
+        fire = np.array([1.0, 0.0, 0.0])  # fire in year 0 only
+        crop_out, _ = Emit.reduce_from_fire(n, crop=crop, fire=fire)
+        # Year 0: above=10*(1-0.85)=1.5, below=5 → total=6.5
+        # Years 1-2: above=10, below=5 → total=15
+        np.testing.assert_allclose(crop_out, [6.5, 15.0, 15.0])
+
+    def test_fire_reduces_tree_above_ground_by_tree_combustion_factor(self):
+        # combustion_factor["tree"] = 0.74
+        # After fire: above = above * (1 - 0.74) = above * 0.26
+        n = 2
+        tree = [_make_biomass_model(n, [10.0, 10.0], [5.0, 5.0])]
+        fire = np.array([1.0, 0.0])
+        _, tree_out = Emit.reduce_from_fire(n, tree=tree, fire=fire)
+        # Year 0: above=10*(1-0.74)=2.6, below=5 → total=7.6
+        # Year 1: above=10, below=5 → total=15
+        np.testing.assert_allclose(tree_out, [7.6, 15.0])
+
+    def test_empty_inputs_return_zeros(self):
+        n = 5
+        crop_out, tree_out = Emit.reduce_from_fire(n, crop=[], tree=[], litter=[], fire=np.zeros(n))
+        np.testing.assert_array_equal(crop_out, np.zeros(n))
+        np.testing.assert_array_equal(tree_out, np.zeros(n))
+
+
+class TestSocSink:
+
+    def test_numeric_value_1_tC_increase(self):
+        # A 1 t C/ha increase per year → delta = 1 * 44/12 = 3.6667 t CO2/ha/yr
+        # C_to_CO2_conversion_factor = 44/12
+        mock_fwd = types.SimpleNamespace()
+        mock_fwd.SOC = np.array([[0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]])
+        result = Emit.soc_sink(mock_fwd, no_of_years=1)
+        np.testing.assert_allclose(result, [44.0 / 12], rtol=1e-6)
+
+    def test_constant_soc_returns_zero(self):
+        mock_fwd = types.SimpleNamespace()
+        mock_fwd.SOC = np.full((3, 4), [10.0, 0.0, 0.0, 0.0])
+        result = Emit.soc_sink(mock_fwd, no_of_years=2)
+        np.testing.assert_allclose(result, [0.0, 0.0])
+
+
+class TestTreeSink:
+
+    def test_numeric_value(self):
+        # Total biomass increases by 2 per year (from 8 to 10 to 12).
+        # delta = 2 * 44/12 per year
+        mock_tree = types.SimpleNamespace()
+        mock_tree.stand_biomass = np.array([[5.0, 3.0], [6.0, 4.0], [7.0, 5.0]])
+        result = Emit.tree_sink([mock_tree], no_of_years=2)
+        expected = np.array([2 * 44.0 / 12, 2 * 44.0 / 12])
+        np.testing.assert_allclose(result, expected)
+
+    def test_multiple_trees_are_summed(self):
+        # Two trees each contributing 2 units/year → total delta = 4 * 44/12
+        mock_tree = types.SimpleNamespace()
+        mock_tree.stand_biomass = np.array([[5.0, 3.0], [6.0, 4.0]])
+        result = Emit.tree_sink([mock_tree, mock_tree], no_of_years=1)
+        expected = np.array([4 * 44.0 / 12])
+        np.testing.assert_allclose(result, expected)
+
+
+class TestZeroInputsGiveZeroEmissions:
+
+    def test_fert_emit_zero_for_empty_inputs(self):
+        result = Emit.fert_emit(litter=[], fert=[], no_of_years=5, gwp=GWP)
+        np.testing.assert_array_equal(result, np.zeros(5))
+
+    def test_nitrogen_emit_zero_for_empty_inputs(self):
+        result = Emit.nitrogen_emit(
+            no_of_years=5,
+            crop=[],
+            tree=[],
+            litter=[],
+            fire=np.zeros(5),
+            gwp=GWP,
+        )
+        np.testing.assert_array_equal(result, np.zeros(5))

--- a/shamba/tests/test_roth_c.py
+++ b/shamba/tests/test_roth_c.py
@@ -1,0 +1,235 @@
+"""Tests for the RothC soil carbon model.
+
+Covers:
+  - get_rmf(): rate modifying factor (qualitative + code-logic tests)
+  - forward_roth_c: shape, non-negativity, round-trip stability
+  - inverse_roth_c: equilibrium pools sum to Ceq, non-negativity
+
+Numeric regression tests (marked skip) must have their expected values confirmed
+against the official RothC Python reference repository before activating.
+See the FIXME comment in test_forward_solver_numeric_regression for the input spec.
+"""
+
+import types
+
+import numpy as np
+import pytest
+
+from model.climate import ClimateData
+import model.soil_params as soil_params
+import model.soil_models.roth_c.roth_c as roth_c
+import model.soil_models.roth_c.forward_roth_c as forward_roth_c
+import model.soil_models.roth_c.inverse_roth_c as inverse_roth_c
+
+
+# ---------------------------------------------------------------------------
+# Shared test fixtures
+# ---------------------------------------------------------------------------
+
+def _make_soil(Cy0=40.0, clay=20.0):
+    return soil_params.create({"Cy0": Cy0, "clay": clay})
+
+
+def _make_wet_climate(temp=20.0):
+    """Always-wet climate: rain > evap every month.
+
+    When rain always exceeds evaporation the RMF code short-circuits and
+    returns b.mean() = 1.0 without evaluating the temperature or cover factors.
+    """
+    return ClimateData(
+        temperature=np.full(12, temp),
+        rain=np.full(12, 100.0),
+        evaporation=np.full(12, 40.0),
+    )
+
+
+def _make_drought_climate():
+    """Severe drought: 4 months where rain is far below evap (deficit ~−60 mm/month)."""
+    return ClimateData(
+        temperature=np.full(12, 20.0),
+        rain=np.array([100, 100, 100, 100, 100, 100, 20, 20, 20, 20, 100, 100], dtype=float),
+        evaporation=np.array([40, 40, 40, 40, 40, 40, 80, 80, 80, 80, 40, 40], dtype=float),
+    )
+
+
+def _make_mild_drought_climate():
+    """Mild drought: 4 months where rain is slightly below evap (deficit ~−10 mm/month)."""
+    return ClimateData(
+        temperature=np.full(12, 20.0),
+        rain=np.array([100, 100, 100, 100, 100, 100, 60, 60, 60, 60, 100, 100], dtype=float),
+        evaporation=np.array([40, 40, 40, 40, 40, 40, 70, 70, 70, 70, 40, 40], dtype=float),
+    )
+
+
+def _make_litter_input(n_years, carbon_per_year):
+    """Create a mock litter object providing constant carbon input each year.
+
+    forward_roth_c reads litter via emit.reduce_from_fire, which sums
+    litter.output["above"]["carbon"] and litter.output["below"]["carbon"].
+    """
+    obj = types.SimpleNamespace()
+    obj.output = {
+        "above": {
+            "carbon": np.full(n_years, carbon_per_year),
+            "nitrogen": np.zeros(n_years),
+            "DMon": np.zeros(n_years),
+            "DMoff": np.zeros(n_years),
+        },
+        "below": {
+            "carbon": np.zeros(n_years),
+            "nitrogen": np.zeros(n_years),
+            "DMon": np.zeros(n_years),
+            "DMoff": np.zeros(n_years),
+        },
+    }
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# get_rmf tests
+# ---------------------------------------------------------------------------
+
+class TestGetRmf:
+
+    def test_rmf_equals_one_when_rain_always_exceeds_evap(self):
+        # When deficit = rain - evap > 0 every month, the code sets
+        # rain_always_exceeds_evaporation = True and returns b.mean() = 1.0
+        # before applying temperature or cover factors.
+        soil = _make_soil()
+        climate = _make_wet_climate()
+        cover = np.zeros(12)
+        n_years = 5
+        result = roth_c.get_rmf(climate=climate, cover=cover, soil=soil, no_of_years=n_years)
+        np.testing.assert_allclose(result, np.ones(n_years))
+
+    def test_severe_drought_gives_lower_rmf_than_mild_drought(self):
+        # Both climates go through the full RMF calculation (both have some months
+        # where rain < evap). Severe drought accumulates a larger soil moisture deficit,
+        # so the moisture factor b is lower → lower RMF.
+        # Note: the "always wet" bypass returns b.mean()=1.0 *without* the temperature
+        # factor, so wet vs drought is not a valid comparison for this test.
+        soil = _make_soil()
+        cover = np.zeros(12)
+        rmf_mild = roth_c.get_rmf(_make_mild_drought_climate(), cover, soil, no_of_years=1)
+        rmf_severe = roth_c.get_rmf(_make_drought_climate(), cover, soil, no_of_years=1)
+        assert rmf_severe[0] < rmf_mild[0]
+
+    def test_soil_cover_reduces_rmf_under_drought(self):
+        # Covered soil uses a c factor of 0.6 instead of 1.0.
+        soil = _make_soil()
+        drought = _make_drought_climate()
+        rmf_bare = roth_c.get_rmf(drought, np.zeros(12), soil, no_of_years=1)
+        rmf_covered = roth_c.get_rmf(drought, np.ones(12), soil, no_of_years=1)
+        assert rmf_covered[0] < rmf_bare[0]
+
+
+# ---------------------------------------------------------------------------
+# inverse_roth_c tests
+# ---------------------------------------------------------------------------
+
+class TestInverseRothC:
+
+    def test_equilibrium_pools_sum_to_approximately_ceq(self):
+        # The inverse solver searches for pools where sum(eq_C) + iom ≈ Ceq.
+        soil = _make_soil(Cy0=40.0, clay=20.0)
+        inv = inverse_roth_c.create(soil, _make_drought_climate(), cover=np.zeros(12))
+        total_C = float(np.sum(inv.eq_C)) + soil.iom
+        # The inverse solver uses a coarse 0.1-step grid search, so convergence
+        # is approximate. 20% tolerance accounts for this grid resolution.
+        assert abs(total_C - soil.Ceq) / soil.Ceq < 0.20
+
+    def test_equilibrium_pools_are_non_negative(self):
+        soil = _make_soil()
+        inv = inverse_roth_c.create(soil, _make_drought_climate(), cover=np.zeros(12))
+        assert all(v >= 0 for v in inv.eq_C)
+
+
+# ---------------------------------------------------------------------------
+# forward_roth_c tests
+# ---------------------------------------------------------------------------
+
+class TestForwardRothC:
+
+    def test_soc_has_correct_shape(self):
+        # fwd.SOC is a list of lists after marshmallow deserialisation.
+        n_years = 5
+        soil = _make_soil()
+        Ci = np.array([0.1, 10.0, 0.0, 0.0])
+        fwd = forward_roth_c.create(soil, _make_drought_climate(), np.zeros(12), Ci, n_years)
+        assert np.array(fwd.SOC).shape == (n_years + 1, 4)
+
+    def test_pools_do_not_go_substantially_negative(self):
+        # The RothC ODE solver does not enforce strict positivity. Fast-decaying
+        # pools (DPM k ≈ 10×RMF) can undershoot to tiny floating-point negatives
+        # when approaching zero with no carbon input. The meaningful constraint is
+        # that no pool goes substantially negative (i.e. > 1e-6 t C/ha below zero).
+        # fwd.SOC is a list of lists after marshmallow deserialisation.
+        Ci = np.array([0.1, 10.0, 0.0, 0.0])
+        fwd = forward_roth_c.create(
+            _make_soil(), _make_drought_climate(), np.zeros(12), Ci, no_of_years=10
+        )
+        assert np.all(np.array(fwd.SOC) >= -1e-6)
+
+    def test_inverse_forward_round_trip_is_stable(self):
+        # Get equilibrium pools from the inverse solver.
+        # Run forward with those pools and the matching equilibrium carbon input.
+        # Total carbon should remain approximately constant (within 30% over 10 years).
+        #
+        # Note: the inverse solver uses a coarse 0.1-step grid search so the
+        # round-trip is only approximate. The 30% tolerance accounts for this.
+        n_years = 10
+        soil = _make_soil(Cy0=40.0, clay=20.0)
+        climate = _make_drought_climate()
+        cover = np.zeros(12)
+
+        inv = inverse_roth_c.create(soil, climate, cover)
+        Ci = np.array(inv.eq_C)
+        litter = _make_litter_input(n_years, inv.input_C)
+
+        fwd = forward_roth_c.create(
+            soil, climate, cover, Ci, n_years,
+            litter=[litter], fire=np.zeros(n_years),
+        )
+
+        total_start = float(np.sum(fwd.SOC[0]))
+        total_end = float(np.sum(fwd.SOC[-1]))
+        relative_change = abs(total_end - total_start) / total_start
+        assert relative_change < 0.30, (
+            f"Carbon pools should be approximately stable near equilibrium; "
+            f"relative change was {relative_change:.1%}"
+        )
+
+    @pytest.mark.skip(
+        reason=(
+            "Numeric regression values must be confirmed against the official "
+            "RothC Python reference repository before activating this test. "
+            "See the FIXME comment below for the input specification."
+        )
+    )
+    def test_forward_solver_numeric_regression(self):
+        # FIXME: Run the official RothC Python reference repository on these inputs
+        # and record the expected pool values (DPM, RPM, BIO, HUM) at year 5 below.
+        #
+        # Inputs to use:
+        #   Cy0=40.0, clay=20.0, depth=30 (default)
+        #   climate: temp=20°C constant, rain=[100]*6+[20]*6, evap=[40]*6+[80]*6 mm
+        #   cover = zeros (bare soil), no_of_years=5
+        #   Ci = [0.1, 10.0, 0.0, 0.0]
+        #   litter input: use inv.input_C from inverse_roth_c.create() on same soil/climate
+        #
+        expected_SOC_year5 = [np.nan, np.nan, np.nan, np.nan]  # REPLACE with reference values
+
+        n_years = 5
+        soil = _make_soil(Cy0=40.0, clay=20.0)
+        climate = _make_drought_climate()
+        cover = np.zeros(12)
+        Ci = np.array([0.1, 10.0, 0.0, 0.0])
+
+        inv = inverse_roth_c.create(soil, climate, cover)
+        litter = _make_litter_input(n_years, inv.input_C)
+
+        fwd = forward_roth_c.create(
+            soil, climate, cover, Ci, n_years,
+            litter=[litter], fire=np.zeros(n_years),
+        )
+        np.testing.assert_allclose(fwd.SOC[n_years], expected_SOC_year5, rtol=1e-4)

--- a/shamba/tests/test_validation.py
+++ b/shamba/tests/test_validation.py
@@ -1,0 +1,95 @@
+"""Tests for data validation functions in data_handler.py.
+
+Per the transparency principle in CLAUDE.md: missing management columns must raise
+a clear error. Explicit zeros are required; silent defaults are forbidden.
+"""
+
+import numpy as np
+import pytest
+from model.common.data_handler import (
+    validate_required_mgmt_keys,
+    validate_species_data,
+    resolve_evap_pet,
+    REQUIRED_MGMT_KEYS,
+)
+
+
+def _minimal_valid_mgmt_dict():
+    return {key: np.zeros(5) for key in REQUIRED_MGMT_KEYS}
+
+
+class TestValidateRequiredMgmtKeys:
+
+    def test_passes_when_all_required_keys_present(self):
+        assert validate_required_mgmt_keys(_minimal_valid_mgmt_dict()) == []
+
+    def test_error_names_missing_keys_in_single_message(self):
+        # All missing keys must be reported in one message (not one per key).
+        data = _minimal_valid_mgmt_dict()
+        del data["fire_on_base"]
+        del data["base_sf_qty1"]
+        errors = validate_required_mgmt_keys(data)
+        assert len(errors) == 1
+        assert "fire_on_base" in errors[0]
+        assert "base_sf_qty1" in errors[0]
+
+
+class TestValidateSpeciesData:
+
+    def test_passes_when_age_and_diam_present_for_declared_species(self):
+        data = {
+            "base_species1": np.array([1.0]),
+            "age_sp1": np.array([1.0, 2.0, 3.0]),
+            "diam_sp1": np.array([5.0, 8.0, 12.0]),
+        }
+        assert validate_species_data(data) == []
+
+    def test_passes_when_age_and_biomass_present_without_diam(self):
+        data = {
+            "base_species1": np.array([1.0]),
+            "age_sp1": np.array([1.0, 2.0, 3.0]),
+            "biomass_sp1": np.array([10.0, 25.0, 50.0]),
+        }
+        assert validate_species_data(data) == []
+
+    def test_error_when_size_data_missing_for_declared_species(self):
+        # base_species1 = 2 → age_sp2 and at least one of diam_sp2/biomass_sp2 required.
+        data = {"base_species1": np.array([2.0])}
+        errors = validate_species_data(data)
+        assert any("age_sp2" in e for e in errors)
+        assert any("diam_sp2" in e and "biomass_sp2" in e for e in errors)
+
+    def test_no_false_positive_for_age_when_size_absent(self):
+        # age_sp3 present but neither diam_sp3 nor biomass_sp3 absent —
+        # must report the combined size error, but not report age_sp3 as missing.
+        data = {
+            "proj_species1": np.array([3.0]),
+            "age_sp3": np.array([1.0, 2.0]),
+        }
+        errors = validate_species_data(data)
+        assert any("diam_sp3" in e and "biomass_sp3" in e for e in errors)
+        assert not any("age_sp3" in e for e in errors)
+
+    def test_biomass_sp_recognised_as_valid_header(self):
+        from model.common.data_handler import get_header_type
+        assert get_header_type("biomass_sp1") == "non-negative float"
+        assert get_header_type("biomass_sp3") == "non-negative float"
+
+
+class TestResolveEvapPet:
+
+    def test_evap_wins_and_pet_discarded_when_both_present(self):
+        evap = np.array([10.0, 20.0])
+        result = resolve_evap_pet({"evap": evap.copy(), "pet": np.array([99.0, 99.0])})
+        assert "pet" not in result
+        np.testing.assert_array_equal(result["evap"], evap)
+
+    def test_pet_converted_to_evap_via_open_pan_factor(self):
+        # evap = pet / 0.75 → pet=75 gives evap=100
+        result = resolve_evap_pet({"pet": np.array([75.0, 150.0])})
+        assert "pet" not in result
+        np.testing.assert_allclose(result["evap"], [100.0, 200.0])
+
+    def test_raises_when_neither_evap_nor_pet_present(self):
+        with pytest.raises(ValueError):
+            resolve_evap_pet({"rain": np.array([50.0])})


### PR DESCRIPTION
Add unit tests and TEST_COVERAGE.md for validation, emit, allometric, and RothC

Covers: data_handler validation functions, emit.py building blocks, tree_growth allometric equations and growth curves (including direct AGB input path), and RothC rate-modifying factor and solver round-trip.

TEST_COVERAGE.md documents all tests across the suite including the split-file integration tests (test_integration_split_file.py).

Used: claude-sonnet-4-6 shamba-model/shamba-pm#14 