### PR TITLE
Restructure data pipeline

### DIFF
--- a/shamba/model/climate.py
+++ b/shamba/model/climate.py
@@ -13,7 +13,7 @@ import numpy as np
 from marshmallow import Schema, fields, post_load
 
 from model.common import csv_handler
-from model.common.data_sources.climate import get_climate_data, ClimateStats
+from model.common.data_sources.climate import get_climate_data
 
 
 def validate_monthly_list_length(lst):
@@ -140,31 +140,9 @@ def from_location(location, use_climate_api: bool, climate_vectors=None) -> Clim
         climate_result = get_climate_data(latitude=latitude, longitude=longitude)
 
         if climate_result is not None:
-            temp_stats, rain_stats, evap_stats = climate_result
-            # PET → evap conversion applies to both mean and std
-            evap_stats = [ClimateStats(s.mean / 0.75, s.std / 0.75) for s in evap_stats]
-
-            temperature    = [s.mean for s in temp_stats]
-            rain           = [s.mean for s in rain_stats]
-            evaporation    = [s.mean for s in evap_stats]
-            temperature_std = [s.std for s in temp_stats]
-            rain_std        = [s.std for s in rain_stats]
-            evaporation_std = [s.std for s in evap_stats]
-
-            params = {"temperature": temperature, "rain": rain, "evaporation": evaporation}
-            schema = ClimateDataSchema()
-            errors = schema.validate(params)
-            if errors != {}:
-                print(f"Errors in climate data: {str(errors)}")
-
-            return ClimateData(
-                temperature=temperature,
-                rain=rain,
-                evaporation=evaporation,
-                temperature_std=temperature_std,
-                rain_std=rain_std,
-                evaporation_std=evaporation_std,
-            )
+            temp, rain, evap = climate_result
+            evap = evap / 0.75  # PET → evaporation
+            return from_vectors(temp, rain, evap)
 
         print("Climate API unavailable — falling back to local climate data.")
 

--- a/shamba/model/climate.py
+++ b/shamba/model/climate.py
@@ -117,17 +117,17 @@ def from_vectors(temperature, rain, evaporation) -> ClimateData:
     )
 
 
-def from_location(location, use_api: bool, climate_vectors=None) -> ClimateData:
+def from_location(location, use_climate_api: bool, climate_vectors=None) -> ClimateData:
     """Construct Climate object for a given location.
 
     Priority order:
-      1. Climate API (if use_api=True and call succeeds)
+      1. Climate API (if use_climate_api=True and call succeeds)
       2. climate_vectors from split input file (temp/rain/evap columns)
       3. Local climate.csv file
 
     Args:
         location: (latitude, longitude) tuple
-        use_api: whether to attempt the climate API
+        use_climate_api: whether to attempt the climate API
         climate_vectors: optional tuple of (temperature, rain, evaporation)
             arrays from the split _climate_cover_data.csv file
     Returns:
@@ -136,7 +136,7 @@ def from_location(location, use_api: bool, climate_vectors=None) -> ClimateData:
     latitude = location[0]
     longitude = location[1]
 
-    if use_api:
+    if use_climate_api:
         climate_result = get_climate_data(latitude=latitude, longitude=longitude)
 
         if climate_result is not None:

--- a/shamba/model/common/calculate_emissions.py
+++ b/shamba/model/common/calculate_emissions.py
@@ -564,7 +564,8 @@ def handle_intervention(
     soil_override: Optional[SoilParams.SoilParamsData] = None,
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY,
     gwp: dict = CONSTANTS.GWP_list[CONSTANTS.DEFAULT_GWP],
-    use_api: bool = CONSTANTS.DEFAULT_USE_API,
+    use_climate_api: bool = CONSTANTS.DEFAULT_USE_CLIMATE_API,
+    use_soil_api: bool = CONSTANTS.DEFAULT_USE_SOIL_API,
     emission_factors: Emit.EmissionFactors = Emit.EmissionFactors()
 ):
     no_of_years = get_int(CONSTANTS.NO_OF_YEARS_KEY, intervention_input)
@@ -581,7 +582,7 @@ def handle_intervention(
             intervention_input["rain"],
             intervention_input["evap"],
         )
-    climate = Climate.from_location(location, use_api=use_api, climate_vectors=climate_vectors)
+    climate = Climate.from_location(location, use_climate_api=use_climate_api, climate_vectors=climate_vectors)
 
     # ----------
     # SOIL EQUILIBRIUM SOLVE
@@ -590,7 +591,7 @@ def handle_intervention(
         soil = soil_override
     else:
         soil = SoilParams.get_soil_params(
-            location=location, use_api=use_api, plot_index=plot_index, plot_id=plot_id
+            location=location, use_soil_api=use_soil_api, plot_index=plot_index, plot_id=plot_id
         )
 
     # inverse uses one monthly vector of climate data, but climate is a 12 * years vector, so average:

--- a/shamba/model/common/calculate_emissions.py
+++ b/shamba/model/common/calculate_emissions.py
@@ -42,7 +42,7 @@ def get_location(year_input: Dict[str, Any]) -> Tuple[float, float]:
 # TREE MODEL
 # ----------
 class GetTreeModelReturnData(NamedTuple):
-    tree_base: TreeModel.TreeModel
+    tree_base: List[TreeModel.TreeModel]
     tree_projects: List[TreeModel.TreeModel]
     tree_growths: List[TreeGrowth.TreeGrowth]
 
@@ -50,49 +50,61 @@ class GetTreeModelReturnData(NamedTuple):
 def get_tree_model_data(
     intervention_input: Dict[str, Union[float, int]],
     no_of_years: int,
-    no_of_cohorts: int,
+    no_of_base_cohorts: int,
+    no_of_proj_cohorts: int,
     allometry: List[str],
 ) -> GetTreeModelReturnData:
     # Tree params: read species codes directly from vector-format keys
-    tree_par_base = TreeParams.from_species_index(
-        int(np.atleast_1d(intervention_input["base_species1"])[0])
-    )
-    tree_params = [
+    base_tree_params = [
+        TreeParams.from_species_index(
+            int(np.atleast_1d(intervention_input[f"base_species{i + 1}"])[0])
+        )
+        for i in range(no_of_base_cohorts)
+    ]
+    proj_tree_params = [
         TreeParams.from_species_index(
             int(np.atleast_1d(intervention_input[f"proj_species{i + 1}"])[0])
         )
-        for i in range(no_of_cohorts)
+        for i in range(no_of_proj_cohorts)
     ]
 
     # Tree growth
-    growth_base = TreeGrowth.create_baseline_tree_growths(
-        intervention_input, [tree_par_base], allometry, cohort_count=1
-    )[0]
-    tree_growths = TreeGrowth.create_tree_growths(
-        intervention_input, tree_params, allometry, no_of_cohorts
+    base_tree_growths = TreeGrowth.create_baseline_tree_growths(
+        intervention_input, base_tree_params, allometry, cohort_count=no_of_base_cohorts
+    )
+    proj_tree_growths = TreeGrowth.create_tree_growths(
+        intervention_input, proj_tree_params, allometry, no_of_proj_cohorts
     )
 
     # Thinning and mortality: read pre-built vectors directly from input.
-    # TODO: baseline is assumed to always have one cohort — confirm whether multi-cohort
-    # baselines are possible and, if so, loop over base cohorts as is done for project cohorts.
-    # Baseline always has one cohort; project reads per-cohort arrays indexed 1..no_of_cohorts.
-    thinning_base = intervention_input["thin_base_cohort1"]
-    thinning_fraction_left_base = np.array([
-        1,
-        float(np.atleast_1d(intervention_input["thin_base_br_cohort1"])[0]),
-        float(np.atleast_1d(intervention_input["thin_base_st_cohort1"])[0]),
-        1, 1,
-    ])
-    mortality_base = intervention_input["mort_base_cohort1"]
-    mortality_fraction_left_base = np.array([
-        1,
-        float(np.atleast_1d(intervention_input["mort_base_br_cohort1"])[0]),
-        float(np.atleast_1d(intervention_input["mort_base_st_cohort1"])[0]),
-        1, 1,
-    ])
+
+    thinnings_base = [
+        intervention_input[f"thin_base_cohort{i + 1}"] for i in range(no_of_base_cohorts)
+    ]
+    thinning_fractions_left_base = [
+        np.array([
+            1,
+            float(np.atleast_1d(intervention_input[f"thin_base_br_cohort{i + 1}"])[0]),
+            float(np.atleast_1d(intervention_input[f"thin_base_st_cohort{i + 1}"])[0]),
+            1, 1,
+        ])
+        for i in range(no_of_base_cohorts)
+    ]
+    mortalities_base = [
+        intervention_input[f"mort_base_cohort{i + 1}"] for i in range(no_of_base_cohorts)
+    ]
+    mortality_fractions_left_base = [
+        np.array([
+            1,
+            float(np.atleast_1d(intervention_input[f"mort_base_br_cohort{i + 1}"])[0]),
+            float(np.atleast_1d(intervention_input[f"mort_base_st_cohort{i + 1}"])[0]),
+            1, 1,
+        ])
+        for i in range(no_of_base_cohorts)
+    ]
 
     thinnings_project = [
-        intervention_input[f"thin_proj_cohort{i + 1}"] for i in range(no_of_cohorts)
+        intervention_input[f"thin_proj_cohort{i + 1}"] for i in range(no_of_proj_cohorts)
     ]
     thinning_fractions_project = [
         np.array([
@@ -101,10 +113,10 @@ def get_tree_model_data(
             float(np.atleast_1d(intervention_input[f"thin_proj_st_cohort{i + 1}"])[0]),
             1, 1,
         ])
-        for i in range(no_of_cohorts)
+        for i in range(no_of_proj_cohorts)
     ]
     mortalities_project = [
-        intervention_input[f"mort_proj_cohort{i + 1}"] for i in range(no_of_cohorts)
+        intervention_input[f"mort_proj_cohort{i + 1}"] for i in range(no_of_proj_cohorts)
     ]
     mortality_fractions_project = [
         np.array([
@@ -113,35 +125,37 @@ def get_tree_model_data(
             float(np.atleast_1d(intervention_input[f"mort_proj_st_cohort{i + 1}"])[0]),
             1, 1,
         ])
-        for i in range(no_of_cohorts)
+        for i in range(no_of_proj_cohorts)
     ]
 
-    tree_base = TreeModel.from_defaults(
-        tree_params=tree_par_base,
-        tree_growth=growth_base,
-        year_planted=int(np.atleast_1d(intervention_input["base_plant_yr1"])[0]),
-        stand_density=int(np.atleast_1d(intervention_input["base_plant_dens1"])[0]),
-        thinning=thinning_base,
-        thinning_fraction=thinning_fraction_left_base,
-        mortality=mortality_base,
-        mortality_fraction=mortality_fraction_left_base,
+    tree_bases = TreeModel.create_tree_projects(
+        csv_input_data=intervention_input,
+        tree_params=base_tree_params,
+        growths=base_tree_growths,
+        thinnings_project=thinnings_base,
+        thinning_fractions_project=thinning_fractions_left_base,
+        mortalities_project=mortalities_base,
+        mortality_fractions_project=mortality_fractions_left_base,
         no_of_years=no_of_years,
+        cohort_count=no_of_base_cohorts,
+        type = "base"
     )
 
     tree_projects = TreeModel.create_tree_projects(
         csv_input_data=intervention_input,
-        tree_params=tree_params,
-        growths=tree_growths,
+        tree_params=proj_tree_params,
+        growths=proj_tree_growths,
         thinnings_project=thinnings_project,
         thinning_fractions_project=thinning_fractions_project,
         mortalities_project=mortalities_project,
         mortality_fractions_project=mortality_fractions_project,
         no_of_years=no_of_years,
-        cohort_count=no_of_cohorts,
+        cohort_count=no_of_proj_cohorts,
+        type = "proj"
     )
 
     return GetTreeModelReturnData(
-        tree_base=tree_base, tree_projects=tree_projects, tree_growths=tree_growths
+        tree_base=tree_bases, tree_projects=tree_projects, tree_growths=proj_tree_growths
     )
 
 
@@ -248,7 +262,7 @@ def get_soil_carbon_data(
     fire_project: np.ndarray,
     crop_base: List[CropModel.CropModelData],
     crop_project: List[CropModel.CropModelData],
-    tree_base: TreeModel.TreeModel,
+    tree_base: List[TreeModel.TreeModel],
     tree_projects: List[TreeModel.TreeModel],
     litter_external_base: LitterModel.LitterModelData,
     litter_external_project: LitterModel.LitterModelData,
@@ -277,7 +291,7 @@ def get_soil_carbon_data(
         Ci=for_soil.SOC[-1],
         no_of_years=no_of_years,
         crop=crop_base,
-        tree=[tree_base],
+        tree=tree_base,
         litter=[litter_external_base],
         fire=fire_base,
     )
@@ -312,7 +326,7 @@ def get_emissions_data(
     project_forward_soil_data: ForwardSoilModelData,
     crop_base: List[CropModel.CropModelData],
     crop_project: List[CropModel.CropModelData],
-    tree_base: TreeModel.TreeModel,
+    tree_base: List[TreeModel.TreeModel],
     tree_projects: List[TreeModel.TreeModel],
     litter_external_base: LitterModel.LitterModelData,
     litter_external_project: LitterModel.LitterModelData,
@@ -330,7 +344,7 @@ def get_emissions_data(
         no_of_years=no_of_years,
         forward_soil_model=base_forward_soil_data,
         crop=crop_base,
-        tree=[tree_base],
+        tree=tree_base,
         litter=[litter_external_base],
         fert=[synthetic_fertiliser_base],
         fire=fire_base,
@@ -492,14 +506,14 @@ def get_tree_emissions(
     no_of_years: int,
     fire_base: np.ndarray,
     fire_project: np.ndarray,
-    tree_base: TreeModel.TreeModel,
+    tree_base: List[TreeModel.TreeModel],
     tree_projects: List[TreeModel.TreeModel],
     gwp: dict,
     emission_factors: Emit.EmissionFactors = Emit.EmissionFactors(),
 ) -> GetEmissionsWithDifferenceReturnData:
     tree_base_emissions = Emit.create(
         no_of_years=no_of_years,
-        tree=[tree_base],
+        tree=tree_base,
         fire=fire_base,
         gwp=gwp,
         emission_factors=emission_factors
@@ -559,7 +573,8 @@ def handle_intervention(
     intervention_input: Dict[str, Union[float, int]],
     create_forward_soil_model,
     create_inverse_soil_model,
-    n_cohorts: int,
+    n_proj_cohorts: int,
+    n_base_cohorts: int,
     plot_index: int,
     soil_override: Optional[SoilParams.SoilParamsData] = None,
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY,
@@ -622,7 +637,8 @@ def handle_intervention(
     tree_model_data = get_tree_model_data(
         no_of_years=no_of_years,
         intervention_input=intervention_input,
-        no_of_cohorts=n_cohorts,
+        no_of_base_cohorts=n_base_cohorts,
+        no_of_proj_cohorts=n_proj_cohorts,
         allometry=allometry
     )
 

--- a/shamba/model/common/calculate_emissions.py
+++ b/shamba/model/common/calculate_emissions.py
@@ -572,34 +572,21 @@ class InterventionReturnData(NamedTuple):
 def handle_intervention(
     intervention_input: Dict[str, Union[float, int]],
     climate: Climate.ClimateData,
+    soil: SoilParams.SoilParamsData,
     create_forward_soil_model,
     create_inverse_soil_model,
     n_proj_cohorts: int,
     n_base_cohorts: int,
     plot_index: int,
-    soil_override: Optional[SoilParams.SoilParamsData] = None,
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY,
     gwp: dict = CONSTANTS.GWP_list[CONSTANTS.DEFAULT_GWP],
-    use_soil_api: bool = CONSTANTS.DEFAULT_USE_SOIL_API,
     emission_factors: Emit.EmissionFactors = Emit.EmissionFactors()
 ):
     no_of_years = get_int(CONSTANTS.NO_OF_YEARS_KEY, intervention_input)
-    plot_id = get_int("plot_name", intervention_input)
-
-    # ----------
-    # LOCATION INFORMATION
-    # ----------
-    location = get_location(intervention_input)
 
     # ----------
     # SOIL EQUILIBRIUM SOLVE
     # ----------
-    if soil_override is not None:
-        soil = soil_override
-    else:
-        soil = SoilParams.get_soil_params(
-            location=location, use_soil_api=use_soil_api, plot_index=plot_index, plot_id=plot_id
-        )
 
     inverse_soil_model = create_inverse_soil_model(soil, climate)
 

--- a/shamba/model/common/calculate_emissions.py
+++ b/shamba/model/common/calculate_emissions.py
@@ -1,6 +1,5 @@
 from typing import Dict, Optional, Union, List, NamedTuple, Tuple, Any, Callable
 from toolz import get, compose  # type: ignore
-from copy import deepcopy
 import numpy as np
 
 import model.climate as Climate

--- a/shamba/model/common/calculate_emissions.py
+++ b/shamba/model/common/calculate_emissions.py
@@ -571,6 +571,7 @@ class InterventionReturnData(NamedTuple):
 
 def handle_intervention(
     intervention_input: Dict[str, Union[float, int]],
+    climate: Climate.ClimateData,
     create_forward_soil_model,
     create_inverse_soil_model,
     n_proj_cohorts: int,
@@ -579,7 +580,6 @@ def handle_intervention(
     soil_override: Optional[SoilParams.SoilParamsData] = None,
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY,
     gwp: dict = CONSTANTS.GWP_list[CONSTANTS.DEFAULT_GWP],
-    use_climate_api: bool = CONSTANTS.DEFAULT_USE_CLIMATE_API,
     use_soil_api: bool = CONSTANTS.DEFAULT_USE_SOIL_API,
     emission_factors: Emit.EmissionFactors = Emit.EmissionFactors()
 ):
@@ -590,14 +590,6 @@ def handle_intervention(
     # LOCATION INFORMATION
     # ----------
     location = get_location(intervention_input)
-    climate_vectors = None
-    if "temp" in intervention_input:
-        climate_vectors = (
-            intervention_input["temp"],
-            intervention_input["rain"],
-            intervention_input["evap"],
-        )
-    climate = Climate.from_location(location, use_climate_api=use_climate_api, climate_vectors=climate_vectors)
 
     # ----------
     # SOIL EQUILIBRIUM SOLVE
@@ -609,13 +601,7 @@ def handle_intervention(
             location=location, use_soil_api=use_soil_api, plot_index=plot_index, plot_id=plot_id
         )
 
-    # inverse uses one monthly vector of climate data, but climate is a 12 * years vector, so average:
-    inverse_climate = deepcopy(climate)
-    inverse_climate.evaporation = np.mean(inverse_climate.evaporation.reshape(-1, 12), axis=0)
-    inverse_climate.temperature = np.mean(inverse_climate.temperature.reshape(-1, 12), axis=0)
-    inverse_climate.rain = np.mean(inverse_climate.rain.reshape(-1, 12), axis=0)
-
-    inverse_soil_model = create_inverse_soil_model(soil, inverse_climate)
+    inverse_soil_model = create_inverse_soil_model(soil, climate)
 
     # ----------
     # MODEL DATA

--- a/shamba/model/common/constants.py
+++ b/shamba/model/common/constants.py
@@ -69,7 +69,8 @@ volatile_frac_organic_fertiliser_default = 0.21  # [(kg NH3-N + NOx-N) / kg N ap
 # -------------------------
 # a) values overwritten by the user's input when shamba_command_line.py is run:
 
-DEFAULT_USE_API = True
+DEFAULT_USE_CLIMATE_API = True
+DEFAULT_USE_SOIL_API = True
 DEFAULT_ALLOMORPHY = "chave dry"
 
 # -------------------------

--- a/shamba/model/common/data_handler.py
+++ b/shamba/model/common/data_handler.py
@@ -95,13 +95,13 @@ GROUPED_HEADER_VALIDATIONS = [
     (r"^(base|proj)_species", [r"^(base|proj)_plant_yr", r"^(base|proj)_plant_dens"]),
     # If a project cohort species N is given, per-cohort thinning/mortality is required.
     # (Cohort 1 is also covered by REQUIRED_MGMT_KEYS; this catches cohorts 2 and above.)
-    (r"^proj_species", [
-        r"^thin_proj_cohort",
-        r"^thin_proj_br_cohort",
-        r"^thin_proj_st_cohort",
-        r"^mort_proj_cohort",
-        r"^mort_proj_br_cohort",
-        r"^mort_proj_st_cohort",
+    (r"^(base|proj)_species", [
+        r"^thin_(base|proj)_cohort",
+        r"^thin_(base|proj)_br_cohort",
+        r"^thin_(base|proj)_st_cohort",
+        r"^mort_(base|proj)_cohort",
+        r"^mort_(base|proj)_br_cohort",
+        r"^mort_(base|proj)_st_cohort",
     ]),
 ]
 
@@ -110,12 +110,8 @@ REQUIRED_MGMT_KEYS = [
     "fire_on_base", "fire_off_base", "fire_on_proj", "fire_off_proj",
     "base_lit_qty1", "proj_lit_qty1",
     "base_sf_qty1", "base_sf_n1", "proj_sf_qty1", "proj_sf_n1",
-    # TODO: baseline is assumed to always have one cohort — confirm whether multi-cohort
-    # baselines are possible and, if so, extend validation and input formats accordingly.
-    # Thinning/mortality — baseline always has one cohort; project requires at least cohort 1.
+    # Thinning/mortality — project always has at least one cohort, baseline may have none.
     # Supply zeros for thinning arrays if no thinning events occur.
-    "thin_base_cohort1", "thin_base_br_cohort1", "thin_base_st_cohort1",
-    "mort_base_cohort1", "mort_base_br_cohort1", "mort_base_st_cohort1",
     "thin_proj_cohort1", "thin_proj_br_cohort1", "thin_proj_st_cohort1",
     "mort_proj_cohort1", "mort_proj_br_cohort1", "mort_proj_st_cohort1",
 ]
@@ -556,10 +552,7 @@ def expand_single_row_data_input(file_path: str):
 
     # --- Tree management ---
     # Build thinning/mortality arrays and copy them to every cohort present in
-    # this scenario.  Base is assumed to have exactly one cohort in the single-row
-    # format; proj can have up to three (species1–species3).
-    # TODO: baseline is assumed to always have one cohort — confirm whether multi-cohort
-    # baselines are possible and, if so, extend this to read base_species2/3 like proj.
+    # this scenario.  Base and proj can each have up to three cohorts (species1–species3).
     tree_data = {}
     for mgmt in ("base", "proj"):
         thinning_array = np.zeros(no_of_years + 1)
@@ -569,10 +562,7 @@ def expand_single_row_data_input(file_path: str):
             if yr > 0:
                 thinning_array[yr] = pc
 
-        if mgmt == "base":
-            cohort_indices = [1]
-        else:
-            cohort_indices = [i for i in range(1, 4) if f"proj_species{i}" in raw] or [1]
+        cohort_indices = [i for i in range(1, 4) if f"{mgmt}_species{i}" in raw] or [1]
 
         for c in cohort_indices:
             tree_data[f"thin_{mgmt}_cohort{c}"] = thinning_array

--- a/shamba/model/common/data_handler.py
+++ b/shamba/model/common/data_handler.py
@@ -182,18 +182,15 @@ _THINNING_MORTALITY_PATTERN = re.compile(r"^(thin|mort)_(base|proj)_")
 def broadcast_to_length(data: dict, target_length: int, keys_to_broadcast: list[str]) -> np.ndarray:
     """Broadcasts or truncates each broadcastable array to target_length.
 
-    Thinning and mortality arrays are exempt from truncation: they carry
-    N_YEARS+1 entries (year 0 through year N) because the tree model
-    indexes them by year number rather than sequentially.  All other
-    management arrays must be exactly target_length after this call.
+    Most management arrays are interval-valued (one value per year, N_YEARS entries).
+    Thinning and mortality are point events that act on a specific biomass state, so they
+    carry N_YEARS+1 entries — one per simulation state (initial state plus one after each
+    year of growth). These arrays are exempt from truncation here; all others must be
+    exactly target_length after this call.
     """
     for key, arr in data.items():
         if key in keys_to_broadcast and arr.size < target_length:
             data[key] = np.tile(arr, target_length // arr.size + 1)[:target_length]
-            # TODO: thinning and mortality arrays use N_YEARS+1 entries (including year 0),
-            # while other management arrays use N_YEARS. This inconsistency should be resolved
-            # in a future branch — either standardise on N_YEARS throughout, or split
-            # thinning/mortality into a separate file with its own permitted_vector_lengths.
         elif key in keys_to_broadcast and arr.size > target_length:
             if _THINNING_MORTALITY_PATTERN.match(key):
                 pass  # year-indexed; must keep N_YEARS+1 entries

--- a/shamba/model/common/data_sources/climate.py
+++ b/shamba/model/common/data_sources/climate.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from collections import defaultdict
 import requests
 import socket
-from typing import List, Any, Dict, Optional, Tuple, NamedTuple
+from typing import List, Any, Dict, Optional, Tuple
 
 from model.common.data_sources.helpers import return_none_on_exception
 
@@ -12,80 +12,52 @@ MONTHS_COUNT = 12
 API_URL = "https://archive-api.open-meteo.com/v1/archive"
 
 
-class ClimateStats(NamedTuple):
-    """Inter-annual mean and standard deviation for one calendar month."""
-    mean: float
-    std: float
-
-
-def compute_monthly_mean_std(
+def aggregate_daily_to_monthly(
     daily_values: np.ndarray,
     date_strings: List[str],
     aggregate_fn,
-) -> List[ClimateStats]:
-    """
-    Compute inter-annual mean and standard deviation for each calendar month.
+) -> np.ndarray:
+    """Aggregate daily values to monthly scalars, returning a flat 12*n_years array.
 
-    For each calendar month (1–12):
-      1. For each year, aggregate the daily values within that (year, month)
-         using aggregate_fn — np.mean for temperature, np.sum for rain/ET.
-      2. Collect the resulting annual scalars across all years (~30 values).
-      3. Return ClimateStats(mean, std) across those annual scalars.
-
-    std uses ddof=1 (sample standard deviation). Returns std=0.0 if fewer than
-    two years of data are present for a month.
+    Values are ordered year-major: [Jan_y1, Feb_y1, ..., Dec_y1, Jan_y2, ...].
 
     Args:
         daily_values: 1-D array of daily values, aligned with date_strings.
         date_strings: list of ISO date strings (e.g. "1995-01-15") from the API.
-        aggregate_fn: function applied to a list of daily values within one
-            (year, month) to produce an annual scalar, e.g. np.mean or np.sum.
+        aggregate_fn: applied to daily values within each (year, month), e.g.
+            np.mean for temperature, np.sum for rain/ET.
 
     Returns:
-        List of 12 ClimateStats, one per calendar month (January first).
+        Flat array of length 12 * n_years.
     """
     year_month_vals: Dict[Tuple[int, int], List[float]] = defaultdict(list)
     for date_str, val in zip(date_strings, daily_values):
         year, month = int(date_str[:4]), int(date_str[5:7])
         year_month_vals[(year, month)].append(float(val))
 
+    years = sorted({y for y, m in year_month_vals})
     result = []
-    for month in range(1, 13):
-        annual_scalars = [
-            aggregate_fn(vals)
-            for (y, m), vals in sorted(year_month_vals.items())
-            if m == month
-        ]
-        if len(annual_scalars) > 1:
-            result.append(ClimateStats(
-                mean=float(np.mean(annual_scalars)),
-                std=float(np.std(annual_scalars, ddof=1)),
-            ))
-        else:
-            mean_val = float(np.mean(annual_scalars)) if annual_scalars else 0.0
-            result.append(ClimateStats(mean=mean_val, std=0.0))
+    for year in years:
+        for month in range(1, 13):
+            vals = year_month_vals.get((year, month), [])
+            result.append(float(aggregate_fn(vals)) if vals else 0.0)
 
-    return result
+    return np.array(result)
 
 
 def get_climate_data(
     longitude: float, latitude: float
-) -> Optional[Tuple[List[ClimateStats], List[ClimateStats], List[ClimateStats]]]:
+) -> Optional[Tuple[np.ndarray, np.ndarray, np.ndarray]]:
     """
     Get climate data for a given location from the Open-Meteo archive API.
 
-    Returns a 3-tuple of (temperature_stats, rain_stats, evap_stats), each a list
-    of 12 ClimateStats objects (one per calendar month). Each ClimateStats holds
-    the inter-annual mean and standard deviation across ~30 years of daily data.
-
-    The standard deviation captures inter-annual variability: for each month, daily
-    values within each (year, month) are aggregated first, and then std is taken
-    across the ~30 resulting annual scalars.
+    Returns a 3-tuple of (temperature, rain, evap), each a flat array of length
+    12 * 30 = 360, in year-major month order: [Jan_y1, Feb_y1, ..., Dec_y30].
 
     Returns None if the API call fails.
 
     Note: PET-to-evaporation conversion (/ 0.75) is applied in climate.py
-    from_location(), so both mean and std are in PET units here.
+    from_location(), so evap values here are in PET units.
     """
     current_year = datetime.now().year
     last_full_year = current_year - 1
@@ -112,17 +84,17 @@ def get_climate_data(
     daily_data = api_response["daily"]
     date_strings: List[str] = daily_data["time"]
 
-    temp_stats = compute_monthly_mean_std(
+    temp = aggregate_daily_to_monthly(
         np.array(daily_data["temperature_2m_mean"]), date_strings, np.mean
     )
-    rain_stats = compute_monthly_mean_std(
+    rain = aggregate_daily_to_monthly(
         np.array(daily_data["rain_sum"]), date_strings, np.sum
     )
-    evap_stats = compute_monthly_mean_std(
+    evap = aggregate_daily_to_monthly(
         np.array(daily_data["et0_fao_evapotranspiration"]), date_strings, np.sum
     )
 
-    return temp_stats, rain_stats, evap_stats
+    return temp, rain, evap
 
 
 @return_none_on_exception(requests.RequestException, socket.gaierror)

--- a/shamba/model/common/data_sources/soil.py
+++ b/shamba/model/common/data_sources/soil.py
@@ -64,7 +64,7 @@ def read_soil_table(filename: str, plot_index: int, plot_id: int) -> SoilData:
 
 def get_soil_data(
     location_coordinates: Tuple[float, float],
-    use_api: bool,
+    use_soil_api: bool,
     plot_index: int,
     plot_id: int,
     filename: str,
@@ -72,7 +72,7 @@ def get_soil_data(
     """Get soil data from soilgrids api or from local csv file."""
     api_response: Optional[Dict[str, Any]] = (
         None
-        if not use_api
+        if not use_soil_api
         else get_properties_from_soilgrids_api(
             location=Point(location_coordinates[1], location_coordinates[0])
         )

--- a/shamba/model/common/io_handler.py
+++ b/shamba/model/common/io_handler.py
@@ -46,7 +46,7 @@ def _print_run_summary(arguments):
     rows += [
         ("Use climate API", arguments["use-climate-api"]),
         ("Use soil API", arguments["use-soil-api"]),
-        ("Tree cohorts", arguments["n-cohorts"]),
+        ("Tree cohorts", arguments["n-proj-cohorts"]),
         ("Allometric keys", ", ".join(str(k) for k in arguments["allometric-keys"])),
         ("GWP", gwp_label),
         ("Print to stdout", arguments["print-to-stdout"]),
@@ -248,10 +248,12 @@ ________________________________________________________________________________
     arguments["use-climate-api"] = use_climate_api
     arguments["use-soil-api"] = use_soil_api
 
-    # Prompt for n_cohorts
+    # Prompt for n_{}_cohorts
+    n_base_cohorts = _ask(questionary.text("Enter number of baseline tree cohorts (defaults to 0): ", validate=validate_integer, default="0"))
+    arguments["n-base-cohorts"] = int(n_base_cohorts)
     # Default to 1 if integer not provided
-    n_cohorts = _ask(questionary.text("Enter number of tree cohorts (defaults to 1): ", validate=validate_integer, default="1"))
-    arguments["n-cohorts"] = int(n_cohorts)
+    n_proj_cohorts = _ask(questionary.text("Enter number of project tree cohorts (defaults to 1): ", validate=validate_integer, default="1"))
+    arguments["n-proj-cohorts"] = int(n_proj_cohorts)
 
     # Prompt for allometric key list
     own_allometry = _ask(questionary.confirm(
@@ -272,15 +274,16 @@ ________________________________________________________________________________
     # Prompt for allometric key, cohort by cohort
     cohort_allometric_keys = []
 
-    base_selected_allometric_key = _ask(questionary.select(
-        "Select an Allometric Key for the baseline species:", choices=all_allometric_keys, default=DEFAULT_ALLOMORPHY
-    ))
-
-    cohort_allometric_keys.append(base_selected_allometric_key)
-
-    for i in range(int(n_cohorts)):
+    for i in range(int(n_base_cohorts)):
         selected_allometric_key = _ask(questionary.select(
-            "Select an Allometric Key for each species in the cohort, in the same order as the input file:",
+            "Select an Allometric Key for baseline cohort {i}:".format(i=i+1),
+            choices=all_allometric_keys, default=DEFAULT_ALLOMORPHY,
+        ))
+        cohort_allometric_keys.append(selected_allometric_key)
+
+    for i in range(int(n_proj_cohorts)):
+        selected_allometric_key = _ask(questionary.select(
+            "Select an Allometric Key for project cohort {i}:".format(i=i+1),
             choices=all_allometric_keys, default=DEFAULT_ALLOMORPHY,
         ))
         cohort_allometric_keys.append(selected_allometric_key)

--- a/shamba/model/common/io_handler.py
+++ b/shamba/model/common/io_handler.py
@@ -14,7 +14,8 @@ from model import configuration
 import model.tree_growth as TreeGrowth
 from model.soil_models.soil_model_types import SoilModelType
 from model.common.constants import (
-    DEFAULT_USE_API,
+    DEFAULT_USE_CLIMATE_API,
+    DEFAULT_USE_SOIL_API,
     DEFAULT_ALLOMORPHY,
     DEFAULT_GWP,
     GWP_list,
@@ -43,7 +44,8 @@ def _print_run_summary(arguments):
     else:
         rows.append(("Input file", arguments.get("input-file-name", "")))
     rows += [
-        ("Use API", arguments["use-api"]),
+        ("Use climate API", arguments["use-climate-api"]),
+        ("Use soil API", arguments["use-soil-api"]),
         ("Tree cohorts", arguments["n-cohorts"]),
         ("Allometric keys", ", ".join(str(k) for k in arguments["allometric-keys"])),
         ("GWP", gwp_label),
@@ -240,9 +242,11 @@ ________________________________________________________________________________
         "Do you have split vector data saved in the source directory?", default=False
     ))
 
-    # Prompt for use-api (boolean)
-    use_api = _ask(questionary.confirm("Use API for climate and soil data?", default=DEFAULT_USE_API))
-    arguments["use-api"] = use_api
+    # Prompt for use-{climate|soil}-api (boolean)
+    use_climate_api = _ask(questionary.confirm("Use API for climate data?", default=DEFAULT_USE_CLIMATE_API))
+    use_soil_api = _ask(questionary.confirm("Use API for soil data?", default=DEFAULT_USE_SOIL_API))
+    arguments["use-climate-api"] = use_climate_api
+    arguments["use-soil-api"] = use_soil_api
 
     # Prompt for n_cohorts
     # Default to 1 if integer not provided

--- a/shamba/model/monte_carlo/runner.py
+++ b/shamba/model/monte_carlo/runner.py
@@ -20,7 +20,8 @@ class SampleArgs(NamedTuple):
     perturbed_intervention_input: Dict[str, Any]
     create_forward_soil_model: Callable
     create_inverse_soil_model: Callable
-    n_cohorts: int
+    n_proj_cohorts: int
+    n_base_cohorts: int
     plot_index: int
     soil_params: Optional[SoilParams.SoilParamsData] = None
     emission_factors: EmissionFactors = EmissionFactors()
@@ -35,7 +36,8 @@ def _run_single_sample(arguments: SampleArgs):
         intervention_input=arguments.perturbed_intervention_input,
         create_forward_soil_model=arguments.create_forward_soil_model,
         create_inverse_soil_model=arguments.create_inverse_soil_model,
-        n_cohorts=arguments.n_cohorts,
+        n_proj_cohorts=arguments.n_proj_cohorts,
+        n_base_cohorts=arguments.n_base_cohorts,
         plot_index=arguments.plot_index,
         soil_override=arguments.soil_params,
         allometry=arguments.allometry,
@@ -53,7 +55,8 @@ def run_monte_carlo(
     n_samples: int,
     create_forward_soil_model: Callable,
     create_inverse_soil_model: Callable,
-    n_cohorts: int,
+    n_proj_cohorts: int,
+    n_base_cohorts: int,
     plot_index: int,
     sample_emission_factors: bool = False,
     distribution_dict: Optional[Dict] = None,
@@ -133,7 +136,8 @@ def run_monte_carlo(
                     emission_factors=emission_factor_samples_batch[i],
                     create_forward_soil_model=create_forward_soil_model,
                     create_inverse_soil_model=create_inverse_soil_model,
-                    n_cohorts=n_cohorts,
+                    n_proj_cohorts=n_proj_cohorts,
+                    n_base_cohorts=n_base_cohorts,
                     plot_index=plot_index,
                     soil_params=soil_samples_batch[i],
                     allometry=allometry,

--- a/shamba/model/monte_carlo/runner.py
+++ b/shamba/model/monte_carlo/runner.py
@@ -26,7 +26,8 @@ class SampleArgs(NamedTuple):
     emission_factors: EmissionFactors = EmissionFactors()
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY
     gwp: dict = CONSTANTS.GWP_list[CONSTANTS.DEFAULT_GWP]
-    use_api: bool = CONSTANTS.DEFAULT_USE_API
+    use_climate_api: bool = CONSTANTS.DEFAULT_USE_CLIMATE_API
+    use_soil_api: bool = CONSTANTS.DEFAULT_USE_SOIL_API
 
 
 def _run_single_sample(arguments: SampleArgs):
@@ -39,7 +40,8 @@ def _run_single_sample(arguments: SampleArgs):
         soil_override=arguments.soil_params,
         allometry=arguments.allometry,
         gwp=arguments.gwp,
-        use_api=arguments.use_api,
+        use_climate_api=arguments.use_climate_api,
+        use_soil_api=arguments.use_soil_api,
         emission_factors=arguments.emission_factors
     )
 
@@ -59,7 +61,8 @@ def run_monte_carlo(
     emission_distribution_dict: Dict[str, DistributionSpec] = MODEL_PARAMETER_DISTRIBUTIONS,
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY,
     gwp: dict = CONSTANTS.GWP_list[CONSTANTS.DEFAULT_GWP],
-    use_api: bool = CONSTANTS.DEFAULT_USE_API,
+    use_climate_api: bool = CONSTANTS.DEFAULT_USE_CLIMATE_API,
+    use_soil_api: bool = CONSTANTS.DEFAULT_USE_SOIL_API,
     seed: Optional[int] = None,
     checkpoint_every: int = 0,
     on_checkpoint: Optional[Callable[[int, MCSummaries], None]] = None,
@@ -135,7 +138,8 @@ def run_monte_carlo(
                     soil_params=soil_samples_batch[i],
                     allometry=allometry,
                     gwp=gwp,
-                    use_api=use_api,
+                    use_climate_api=use_climate_api,
+                    use_soil_api=use_soil_api,
                 )
                 for i in range(len(samples_batch))
             ])))

--- a/shamba/model/monte_carlo/runner.py
+++ b/shamba/model/monte_carlo/runner.py
@@ -10,6 +10,7 @@ import numpy as np
 from model.emit import EmissionFactors
 from model.monte_carlo.model_parameter_distributions import MODEL_PARAMETER_DISTRIBUTIONS
 from model.monte_carlo.distribution_handler import DistributionSpec
+from model.climate import ClimateData
 
 class MCSummaries(NamedTuple):
     base: Dict[str, np.ndarray]
@@ -23,27 +24,26 @@ class SampleArgs(NamedTuple):
     n_proj_cohorts: int
     n_base_cohorts: int
     plot_index: int
-    soil_params: Optional[SoilParams.SoilParamsData] = None
+    soil_params: SoilParams.SoilParamsData
+    climate: ClimateData
     emission_factors: EmissionFactors = EmissionFactors()
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY
     gwp: dict = CONSTANTS.GWP_list[CONSTANTS.DEFAULT_GWP]
-    use_climate_api: bool = CONSTANTS.DEFAULT_USE_CLIMATE_API
-    use_soil_api: bool = CONSTANTS.DEFAULT_USE_SOIL_API
+
 
 
 def _run_single_sample(arguments: SampleArgs):
     return handle_intervention(
         intervention_input=arguments.perturbed_intervention_input,
+        climate = arguments.climate,
+        soil = arguments.soil_params,
         create_forward_soil_model=arguments.create_forward_soil_model,
         create_inverse_soil_model=arguments.create_inverse_soil_model,
         n_proj_cohorts=arguments.n_proj_cohorts,
         n_base_cohorts=arguments.n_base_cohorts,
         plot_index=arguments.plot_index,
-        soil_override=arguments.soil_params,
         allometry=arguments.allometry,
         gwp=arguments.gwp,
-        use_climate_api=arguments.use_climate_api,
-        use_soil_api=arguments.use_soil_api,
         emission_factors=arguments.emission_factors
     )
 
@@ -64,8 +64,6 @@ def run_monte_carlo(
     emission_distribution_dict: Dict[str, DistributionSpec] = MODEL_PARAMETER_DISTRIBUTIONS,
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY,
     gwp: dict = CONSTANTS.GWP_list[CONSTANTS.DEFAULT_GWP],
-    use_climate_api: bool = CONSTANTS.DEFAULT_USE_CLIMATE_API,
-    use_soil_api: bool = CONSTANTS.DEFAULT_USE_SOIL_API,
     seed: Optional[int] = None,
     checkpoint_every: int = 0,
     on_checkpoint: Optional[Callable[[int, MCSummaries], None]] = None,
@@ -106,16 +104,6 @@ def run_monte_carlo(
             rng=rng,
         )
 
-    _CLIMATE_STD_ATTRS = {
-        "temp": "temperature_std",
-        "rain": "rain_std",
-        "evap": "evaporation_std",
-    }
-    for i in range(n_samples):
-        for key, std_attr in _CLIMATE_STD_ATTRS.items():
-            if np.any(getattr(climate, std_attr) != 0.0):
-                samples[i][key] = climate_samples[i][key]
-
     if checkpoint_every > 0:
         batch_starts = range(0, n_samples, checkpoint_every)
         batch_size = checkpoint_every
@@ -140,10 +128,9 @@ def run_monte_carlo(
                     n_base_cohorts=n_base_cohorts,
                     plot_index=plot_index,
                     soil_params=soil_samples_batch[i],
+                    climate=climate_samples[i],
                     allometry=allometry,
                     gwp=gwp,
-                    use_climate_api=use_climate_api,
-                    use_soil_api=use_soil_api,
                 )
                 for i in range(len(samples_batch))
             ])))

--- a/shamba/model/monte_carlo/sampler.py
+++ b/shamba/model/monte_carlo/sampler.py
@@ -16,6 +16,7 @@ from model.emit import EmissionFactors
 from model.monte_carlo.model_parameter_distributions import MODEL_PARAMETER_DISTRIBUTIONS, expand_model_param_samples, flatten_model_param_sample
 from model.common.data_handler import get_header_type
 import model.soil_params as SoilParams
+from model.climate import ClimateData
 
 # Climate parameter keys — perturbation is applied as a multiplicative scalar
 # to preserve the seasonal structure of the monthly vector.
@@ -367,7 +368,7 @@ def sample_climate_params(
     climate,
     n_samples: int,
     rng: np.random.Generator,
-) -> List[Dict]:
+) -> List[ClimateData]:
     """Draw N climate parameter dicts from the uncertainty stored in ClimateData.
 
     ClimateData always holds 12-element monthly means and stds. Draws one value
@@ -380,8 +381,7 @@ def sample_climate_params(
         rng: numpy random Generator.
 
     Returns:
-        list of n_samples dicts with keys: 'temp', 'rain', 'evap'.
-        Each value is a 12-element numpy array.
+        list of n_samples ClimateData objects with perturbed climate parameters.
     """
     temp_mean, temp_std = climate.temperature, climate.temperature_std
     rain_mean, rain_std = climate.rain, climate.rain_std
@@ -404,7 +404,14 @@ def sample_climate_params(
         else:
             evap_draw = np.clip(rng.normal(loc=evap_mean, scale=evap_std), 0.0, None)
 
-        results.append({"temp": temp_draw, "rain": rain_draw, "evap": evap_draw})
+        results.append(ClimateData(
+            temperature=temp_draw,
+            rain=rain_draw,
+            evaporation=evap_draw,
+            temperature_std=temp_std,
+            rain_std=rain_std,
+            evaporation_std=evap_std,
+        ))
 
     return results
 

--- a/shamba/model/soil_params.py
+++ b/shamba/model/soil_params.py
@@ -112,7 +112,7 @@ def create(soil_params: Dict[str, Any]) -> SoilParamsData:
 
 def get_soil_params(
     location: Tuple[float, float],
-    use_api: bool,
+    use_soil_api: bool,
     plot_index,
     plot_id,
     filename="soil-info.csv",
@@ -122,7 +122,7 @@ def get_soil_params(
 
     Args:
         location: Tuple of (latitude, longitude) coordinates
-        use_api: Whether to use SoilGrids API or local CSV file
+        use_soil_api: Whether to use SoilGrids API or local CSV file
         plot_index: Index of the plot in the data (0-based)
         plot_id: Identifier of the plot
         filename: Name of local CSV file (default: "soil-info.csv")
@@ -131,7 +131,7 @@ def get_soil_params(
         SoilParamsData: Soil parameters object
     """
 
-    result: SoilData = get_soil_data(location, use_api, plot_index, plot_id, filename)
+    result: SoilData = get_soil_data(location, use_soil_api, plot_index, plot_id, filename)
 
     if result is None:
         raise ValueError("Soil data not found in API or local file. Please provide a local soil file.")

--- a/shamba/model/tree_growth.py
+++ b/shamba/model/tree_growth.py
@@ -666,22 +666,16 @@ def get_growth(csv_input_data, spp_key, tree_params, allometric_key):
     )
 
 
-def create_baseline_tree_growths(csv_input_data, tree_params, allometric_keys, cohort_count=1):
+def create_baseline_tree_growths(csv_input_data, tree_params, allometric_keys, cohort_count):
     """Return a list of Growth objects for baseline cohorts.
-
-    Defaults to one baseline cohort. Increase cohort_count when the baseline
-    contains multiple tree species. Baseline allometry is always at index 0
-    of allometric_keys.
-
-    TODO: baseline is assumed to always have one cohort — confirm whether multi-cohort
-    baselines are possible; cohort_count would need to be wired from input data if so.
+    Baseline allometry always starts at index 0 of allometric_keys.
     """
     return [
         get_growth(
             csv_input_data,
             f"base_species{i + 1}",
             tree_params[i],
-            allometric_key=allometric_keys[0],
+            allometric_key=allometric_keys[i],
         )
         for i in range(cohort_count)
     ]
@@ -690,14 +684,15 @@ def create_baseline_tree_growths(csv_input_data, tree_params, allometric_keys, c
 def create_tree_growths(csv_input_data, tree_params, allometric_keys, cohort_count):
     """Return a list of Growth objects for project cohorts.
 
-    Project allometry starts at index 1 of allometric_keys (index 0 is baseline).
+    Project allometry starts at index (len(allometric_keys) - cohort_count), 
+    after baseline allometry keys.
     """
     return [
         get_growth(
             csv_input_data,
             f"proj_species{i + 1}",
             tree_params[i],
-            allometric_key=allometric_keys[i + 1],
+            allometric_key=allometric_keys[len(allometric_keys) - cohort_count + i],
         )
         for i in range(cohort_count)
     ]

--- a/shamba/model/tree_model.py
+++ b/shamba/model/tree_model.py
@@ -525,13 +525,14 @@ def create_tree_projects(
     mortality_fractions_project,
     no_of_years,
     cohort_count,
+    type,
 ):
     return [
         from_defaults(
             tree_params=tree_params[i],
             tree_growth=growths[i],
-            year_planted=int(np.atleast_1d(csv_input_data[f"proj_plant_yr{i + 1}"])[0]),
-            stand_density=int(np.atleast_1d(csv_input_data[f"proj_plant_dens{i + 1}"])[0]),
+            year_planted=int(np.atleast_1d(csv_input_data[f"{type}_plant_yr{i + 1}"])[0]),
+            stand_density=int(np.atleast_1d(csv_input_data[f"{type}_plant_dens{i + 1}"])[0]),
             thinning=thinnings_project[i],
             thinning_fraction=thinning_fractions_project[i],
             mortality=mortalities_project[i],

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -314,7 +314,7 @@ def setup_project_directory(project_name, arguments):
         files_to_copy.append(str(prefix + "_plot_data.csv"))
         files_to_copy.append(str(prefix + "_mgmt_data.csv"))
         files_to_copy.append(str(prefix + "_tree_size_data.csv"))
-        if arguments["use-api"] is False:
+        if arguments["use-climate-api"] is False:
             files_to_copy.append(str(prefix + "_climate_cover_data.csv"))
     else:
         files_to_copy.append(arguments["input-file-name"])

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -235,13 +235,8 @@ def save_crop_data(base_data, project_data, plot_name, model_type):
             CropParams.save(project, str(project_filename))
 
 
-def write_emissions_csv(configuration, mod_run, n, st, data):
-    # Define the output directory and file name
-    output_dir = Path(configuration.OUTPUT_DIR + f"_{mod_run}/plot_{n+st}")
+def write_emissions_csv(output_dir, n, st, data):
     output_file = output_dir / f"plot_{n+st}_emissions_all_pools_per_year.csv"
-
-    # Ensure the directory exists
-    output_dir.mkdir(parents=True, exist_ok=True)
 
     # Define the header and data rows
     header = [
@@ -446,6 +441,48 @@ def main(n, arguments):
     soil_params = SoilParams.get_soil_params(
         location=location, use_soil_api=use_soil_api, plot_id=plot_id, plot_index=n)
 
+    # Save stuff
+
+    # starting plot output number
+    st = 1
+
+    dir = Path(configuration.OUTPUT_DIR + "_" + mod_run + "\plot_" + str(n + st))
+
+    if os.path.exists(dir):
+        shutil.rmtree(dir)
+    os.makedirs(dir)
+
+    plot_name = str(dir / f"plot_{n + st}")
+
+    datasets = [
+        ("plot", scalar_input_data),
+        ("mgmt", mgmt_input_data),
+        ("tree_size", tree_size_data),
+    ]
+
+    for name, d in datasets:
+        cols = list(d.keys())
+
+        arrays = [np.atleast_1d(np.asarray(d[k], dtype=float)) for k in cols]
+
+        # All columns must be the same length
+        target_len = max(a.size for a in arrays)
+        padded = []
+        for a in arrays:
+            if a.size < target_len:
+                a = np.pad(a, (0, target_len - a.size), constant_values=np.nan)
+            padded.append(a)
+
+        data_to_save = np.column_stack(padded)
+
+        out_path = os.path.join(dir, f"validated_{name}_input_data_{st}.csv")
+        csv_handler.print_csv(file_out=out_path, array=data_to_save, col_names=cols)
+
+    if arguments.get("split-input-file-id") is not None:
+        cols = list(climate_cover_data.keys())
+        data_to_save = np.column_stack([np.asarray(climate_cover_data[k], dtype=float) for k in cols])
+        csv_handler.print_csv(file_out=os.path.join(dir, f"validated_climate_data_{st}.csv"), array=data_to_save, col_names=cols)
+
 
     if arguments["n-samples"]:
         n_samples = arguments["n-samples"]
@@ -472,20 +509,16 @@ def main(n, arguments):
             seed=arguments["seed"],
         )
 
-        st = 1
-        output_dir = Path(configuration.OUTPUT_DIR + f"_{mod_run}") / f"plot_{n + st}"
-        output_dir.mkdir(parents=True, exist_ok=True)
-
         mc_summary = summarise_mc_results(mc_results)
         for scenario, label in [
             (mc_summary.base,    "baseline"),
             (mc_summary.project, "project"),
             (mc_summary.diff,    "diff"),
         ]:
-            write_mc_summary_csv(scenario, str(output_dir / f"plot_{n + st}_mc_{label}.csv"))
+            write_mc_summary_csv(scenario, str(dir / f"plot_{n + st}_mc_{label}.csv"))
 
         write_mc_metadata(
-            output_path=str(output_dir / "mc_run_metadata.txt"),
+            output_path=str(dir / "mc_run_metadata.txt"),
             n_samples=n_samples,
             seed=arguments["seed"],
             soil_params=soil_params,
@@ -495,12 +528,11 @@ def main(n, arguments):
         )
 
         # TODO: the MC path currently writes only the quantile summary CSV.  The
-        # deterministic path (below) also writes validated input CSVs, per-pool
+        # deterministic path (below) also writes per-pool
         # emissions CSVs, soil model CSVs, tree/crop data CSVs, and plots.  Decide
         # which of those outputs are meaningful for an MC run and add them here.
-        # Candidates: validated input CSVs (same for all samples — write once);
-        # soil/climate CSVs from the base run (representative inputs); plots of the
-        # emission distribution (e.g. per-year credible interval fan chart).
+        # Candidates: soil/climate CSVs from the base run (representative inputs); 
+        # plots of the emission distribution (e.g. per-year credible interval fan chart).
 
 
         emit_diffs = [
@@ -509,7 +541,7 @@ def main(n, arguments):
         total_diffs = np.array([float(np.sum(d)) for d in emit_diffs])
         print(
             f"\nMonte Carlo complete: {len(mc_results)} samples\n"
-            f"  Summaries written to: {output_dir}\n"
+            f"  Summaries written to: {dir}\n"
             f"  Total emission difference — mean: {total_diffs.mean():.4f} t CO2 ha^-1  "
             f"  std: {total_diffs.std():.4f} t CO2 ha^-1"
         )
@@ -673,46 +705,6 @@ def main(n, arguments):
 
     # Save stuff
 
-    # starting plot output number
-    st = 1
-
-    dir = configuration.OUTPUT_DIR + "_" + mod_run + "\plot_" + str(n + st)
-
-    if os.path.exists(dir):
-        shutil.rmtree(dir)
-    os.makedirs(dir)
-
-    plot_name = dir + "\plot_" + str(n + st)
-
-    datasets = [
-        ("plot", scalar_input_data),
-        ("mgmt", mgmt_input_data),
-        ("tree_size", tree_size_data),
-    ]
-
-    for name, d in datasets:
-        cols = list(d.keys())
-
-        arrays = [np.atleast_1d(np.asarray(d[k], dtype=float)) for k in cols]
-
-        # All columns must be the same length
-        target_len = max(a.size for a in arrays)
-        padded = []
-        for a in arrays:
-            if a.size < target_len:
-                a = np.pad(a, (0, target_len - a.size), constant_values=np.nan)
-            padded.append(a)
-
-        data_to_save = np.column_stack(padded)
-
-        out_path = os.path.join(dir, f"validated_{name}_input_data_{st}.csv")
-        csv_handler.print_csv(file_out=out_path, array=data_to_save, col_names=cols)
-
-    if arguments.get("split-input-file-id") is not None:
-        cols = list(climate_cover_data.keys())
-        data_to_save = np.column_stack([np.asarray(climate_cover_data[k], dtype=float) for k in cols])
-        csv_handler.print_csv(file_out=os.path.join(dir, f"validated_climate_data_{st}.csv"), array=data_to_save, col_names=cols)
-
     Climate.save(intervention_emissions.climate, plot_name + "_climate.csv")
 
     SoilParams.save(intervention_emissions.soil, plot_name + "_soil.csv")
@@ -784,7 +776,7 @@ def main(n, arguments):
         "crop_difference": intervention_emissions.crop_difference,
     }
 
-    write_emissions_csv(configuration, mod_run, n, st, data)
+    write_emissions_csv(dir, n, st, data)
 
     # Plot stuff
     plot_tree_projects(intervention_emissions.tree_projects, plot_name)
@@ -814,7 +806,7 @@ def main(n, arguments):
     Emit.plot(intervention_emissions.emit_base_emissions, legend_string="baseline")
     Emit.plot(intervention_emissions.emit_project_emissions, legend_string="project")
 
-    plt.savefig(os.path.join(configuration.OUTPUT_DIR, plot_name + "_emissions.png"))
+    plt.savefig(plot_name + "_emissions.png")
     plt.close()
 
     Emit.save(

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -385,9 +385,12 @@ def main(n, arguments):
             target_vector_length=1,
         )
         N_YEARS = int(np.atleast_1d(scalar_input_data["yrs_proj"])[0])
-        # TODO: thinning and mortality arrays use N_YEARS+1 entries (year 0 included);
-        # other management arrays use N_YEARS. N_YEARS+1 is included here to accommodate
-        # both. See the same TODO in broadcast_to_length for full context.
+        # N_YEARS+1 is included for thinning and mortality arrays. Unlike other management
+        # inputs (fire, fertiliser, etc.) which are interval-valued — one value per year —
+        # thinning and mortality are point events that act on a specific biomass state.
+        # The simulation passes through N_YEARS+1 states (initial state plus one after each
+        # year of growth), so these arrays need N_YEARS+1 entries to cover every attachment
+        # point: state_0 → [grow] → state_1 → ... → state_N_YEARS.
         mgmt_input_data = data_handler.read_and_validate_timeseries_by_header(
             file_path=os.path.join(configuration.INPUT_DIR, f"{prefix}_mgmt_data.csv"),
             permitted_vector_lengths=[1, N_YEARS, N_YEARS + 1],

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -429,6 +429,16 @@ def main(n, arguments):
 
     gwp = arguments["gwp"]
 
+    climate_vectors = None
+
+    if "temp" in vector_input_data:
+        climate_vectors = (
+                vector_input_data["temp"],
+                vector_input_data["rain"],
+                vector_input_data["evap"],)
+    
+    climate = Climate.from_location(get_location(vector_input_data), use_climate_api=arguments["use-climate-api"], climate_vectors=climate_vectors)
+
     if arguments["n-samples"]:
         n_samples = arguments["n-samples"]
         if arguments["distribution-file-name"]:
@@ -436,19 +446,11 @@ def main(n, arguments):
             distribution_dict = distribution_handler.load_distributions(distribution_file_path, vector_input_data)
         else:
             distribution_dict = None
-        # TODO: tidy the below up so that it isn't a duplicate of the code at the beginning of handle_intervention()
+
         use_climate_api = arguments["use-climate-api"]
         use_soil_api = arguments["use-soil-api"]
-        no_of_years = int(np.atleast_1d(vector_input_data[CONSTANTS.NO_OF_YEARS_KEY])[0])
         plot_id = vector_input_data["plot_name"] if "plot_name" in vector_input_data else None
         location = get_location(vector_input_data)
-        climate_vectors = None
-        if "temp" in vector_input_data:
-            climate_vectors = (
-                vector_input_data["temp"],
-                vector_input_data["rain"],
-                vector_input_data["evap"],)
-        climate = Climate.from_location(location, use_climate_api=use_climate_api, climate_vectors=climate_vectors)
         soil_params = SoilParams.get_soil_params(
             location=location, use_soil_api=use_soil_api, plot_id=plot_id, plot_index=n
         )
@@ -517,12 +519,12 @@ def main(n, arguments):
     else:
         intervention_emissions = handle_intervention(
             intervention_input=vector_input_data,
+            climate=climate,
             n_proj_cohorts=N_PROJ_COHORTS,
             n_base_cohorts=N_BASE_COHORTS,
             plot_index=n,
             allometry=allometric_keys,
             gwp=gwp,
-            use_climate_api=arguments["use-climate-api"],
             use_soil_api=arguments["use-soil-api"],
             create_forward_soil_model=ForwardSoilModel.create,
             create_inverse_soil_model=InverseSoilModel.create,

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -437,7 +437,15 @@ def main(n, arguments):
                 vector_input_data["rain"],
                 vector_input_data["evap"],)
     
-    climate = Climate.from_location(get_location(vector_input_data), use_climate_api=arguments["use-climate-api"], climate_vectors=climate_vectors)
+    use_climate_api = arguments["use-climate-api"]
+    climate = Climate.from_location(get_location(vector_input_data), use_climate_api=use_climate_api, climate_vectors=climate_vectors)
+
+    use_soil_api = arguments["use-soil-api"]
+    plot_id = vector_input_data["plot_name"] if "plot_name" in vector_input_data else None
+    location = get_location(vector_input_data)
+    soil_params = SoilParams.get_soil_params(
+        location=location, use_soil_api=use_soil_api, plot_id=plot_id, plot_index=n)
+
 
     if arguments["n-samples"]:
         n_samples = arguments["n-samples"]
@@ -446,14 +454,6 @@ def main(n, arguments):
             distribution_dict = distribution_handler.load_distributions(distribution_file_path, vector_input_data)
         else:
             distribution_dict = None
-
-        use_climate_api = arguments["use-climate-api"]
-        use_soil_api = arguments["use-soil-api"]
-        plot_id = vector_input_data["plot_name"] if "plot_name" in vector_input_data else None
-        location = get_location(vector_input_data)
-        soil_params = SoilParams.get_soil_params(
-            location=location, use_soil_api=use_soil_api, plot_id=plot_id, plot_index=n
-        )
 
         mc_results = run_monte_carlo(
             base_input_dict=vector_input_data,
@@ -520,12 +520,12 @@ def main(n, arguments):
         intervention_emissions = handle_intervention(
             intervention_input=vector_input_data,
             climate=climate,
+            soil=soil_params,
             n_proj_cohorts=N_PROJ_COHORTS,
             n_base_cohorts=N_BASE_COHORTS,
             plot_index=n,
             allometry=allometric_keys,
             gwp=gwp,
-            use_soil_api=arguments["use-soil-api"],
             create_forward_soil_model=ForwardSoilModel.create,
             create_inverse_soil_model=InverseSoilModel.create,
         )

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -469,8 +469,6 @@ def main(n, arguments):
             distribution_dict=distribution_dict,
             allometry=allometric_keys,
             gwp=gwp,
-            use_climate_api=arguments["use-climate-api"],
-            use_soil_api=arguments["use-soil-api"],
             seed=arguments["seed"],
         )
 

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -404,7 +404,7 @@ def main(n, arguments):
         )
         vector_input_data = scalar_input_data | mgmt_input_data | tree_size_data
         # _climate_cover_data.csv always provides base_cover and proj_cover.
-        # It may also contain climate data (temp, rain, evap/pet) regardless of use_api,
+        # It may also contain climate data (temp, rain, evap/pet) regardless of use_climate_api,
         # since these are used as a fallback if the API is unavailable. The logic assumes
         # that the file either contains all climate data or none.
         climate_cover_data = data_handler.read_and_validate_timeseries_by_header(
@@ -436,7 +436,8 @@ def main(n, arguments):
         else:
             distribution_dict = None
         # TODO: tidy the below up so that it isn't a duplicate of the code at the beginning of handle_intervention()
-        use_api = arguments["use-api"]
+        use_climate_api = arguments["use-climate-api"]
+        use_soil_api = arguments["use-soil-api"]
         no_of_years = int(np.atleast_1d(vector_input_data[CONSTANTS.NO_OF_YEARS_KEY])[0])
         plot_id = vector_input_data["plot_name"] if "plot_name" in vector_input_data else None
         location = get_location(vector_input_data)
@@ -446,9 +447,9 @@ def main(n, arguments):
                 vector_input_data["temp"],
                 vector_input_data["rain"],
                 vector_input_data["evap"],)
-        climate = Climate.from_location(location, use_api, climate_vectors=climate_vectors)
+        climate = Climate.from_location(location, use_climate_api=use_climate_api, climate_vectors=climate_vectors)
         soil_params = SoilParams.get_soil_params(
-            location=location, use_api=use_api, plot_id=plot_id, plot_index=n
+            location=location, use_soil_api=use_soil_api, plot_id=plot_id, plot_index=n
         )
 
         mc_results = run_monte_carlo(
@@ -464,7 +465,8 @@ def main(n, arguments):
             distribution_dict=distribution_dict,
             allometry=allometric_keys,
             gwp=gwp,
-            use_api=arguments["use-api"],
+            use_climate_api=arguments["use-climate-api"],
+            use_soil_api=arguments["use-soil-api"],
             seed=arguments["seed"],
         )
 
@@ -517,7 +519,8 @@ def main(n, arguments):
             plot_index=n,
             allometry=allometric_keys,
             gwp=gwp,
-            use_api=arguments["use-api"],
+            use_climate_api=arguments["use-climate-api"],
+            use_soil_api=arguments["use-soil-api"],
             create_forward_soil_model=ForwardSoilModel.create,
             create_inverse_soil_model=InverseSoilModel.create,
         )

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -373,7 +373,8 @@ def main(n, arguments):
     configuration.INPUT_DIR = os.path.join(configuration.SAVE_DIR, "input")
     configuration.OUTPUT_DIR = os.path.join(configuration.SAVE_DIR, "output")
 
-    N_COHORTS = arguments["n-cohorts"]
+    N_PROJ_COHORTS = arguments["n-proj-cohorts"]
+    N_BASE_COHORTS = arguments["n-base-cohorts"]
 
     if arguments.get("input-file-name") is not None:
         file_path = os.path.join(configuration.INPUT_DIR, arguments["input-file-name"])
@@ -459,7 +460,8 @@ def main(n, arguments):
             n_samples=n_samples,
             create_forward_soil_model=ForwardSoilModel.create,
             create_inverse_soil_model=InverseSoilModel.create,
-            n_cohorts=N_COHORTS,
+            n_proj_cohorts=N_PROJ_COHORTS,
+            n_base_cohorts=N_BASE_COHORTS,
             plot_index=n,
             sample_emission_factors=arguments["sample-emission-factors"],
             distribution_dict=distribution_dict,
@@ -515,7 +517,8 @@ def main(n, arguments):
     else:
         intervention_emissions = handle_intervention(
             intervention_input=vector_input_data,
-            n_cohorts=N_COHORTS,
+            n_proj_cohorts=N_PROJ_COHORTS,
+            n_base_cohorts=N_BASE_COHORTS,
             plot_index=n,
             allometry=allometric_keys,
             gwp=gwp,

--- a/shamba/tests/test_climate_data.py
+++ b/shamba/tests/test_climate_data.py
@@ -1,17 +1,17 @@
-"""Tests for climate uncertainty capture (Issue P2).
+"""Tests for climate data handling.
 
 Covers:
-- compute_monthly_mean_std: correct inter-annual mean and std for both
-  mean (temperature) and sum (rain/ET) aggregation
+- aggregate_daily_to_monthly: correct values and year-major ordering
+- get_climate_data: returns flat arrays via mocked API
 - from_csv: 3-column CSV gives std=0; 6-column CSV populates std arrays
 - ClimateData: std fields default to zero when not supplied
-- Zero-std: all samples identical (tested via ClimateData construction)
+- from_vectors: means and stds computed correctly from multi-year input
 """
 import numpy as np
 import pytest
-from datetime import date
+import calendar
 
-from model.common.data_sources.climate import ClimateStats, compute_monthly_mean_std
+from model.common.data_sources.climate import aggregate_daily_to_monthly, get_climate_data
 from model.climate import ClimateData, from_csv, from_vectors
 
 
@@ -24,7 +24,6 @@ def make_date_strings(start_year, end_year):
     dates = []
     for year in range(start_year, end_year + 1):
         for month in range(1, 13):
-            import calendar
             days_in_month = calendar.monthrange(year, month)[1]
             for day in range(1, days_in_month + 1):
                 dates.append(f"{year}-{month:02d}-{day:02d}")
@@ -32,78 +31,97 @@ def make_date_strings(start_year, end_year):
 
 
 # ---------------------------------------------------------------------------
-# compute_monthly_mean_std — temperature (mean aggregation)
+# aggregate_daily_to_monthly
 # ---------------------------------------------------------------------------
 
-def test_compute_monthly_mean_std_temperature_known_values():
-    """
-    Two years of synthetic data with known January daily values.
-    Year 1: all Jan days = 10.0  → annual mean = 10.0
-    Year 2: all Jan days = 20.0  → annual mean = 20.0
-    Expected: mean = 15.0, std = std([10, 20], ddof=1) = 7.071...
-    """
-    date_strings = make_date_strings(2000, 2001)
-
-    # Assign 10.0 to all days in 2000, 20.0 to all days in 2001
-    values = np.array([
-        10.0 if ds[:4] == "2000" else 20.0
-        for ds in date_strings
-    ])
-
-    result = compute_monthly_mean_std(values, date_strings, np.mean)
-
-    jan = result[0]  # index 0 = January
-    assert jan.mean == pytest.approx(15.0)
-    assert jan.std  == pytest.approx(np.std([10.0, 20.0], ddof=1))
-
-    # Other months should have the same values (synthetic data is uniform per year)
-    for month_stats in result:
-        assert month_stats.mean == pytest.approx(15.0)
-        assert month_stats.std  == pytest.approx(np.std([10.0, 20.0], ddof=1))
-
-
-def test_compute_monthly_mean_std_returns_twelve_entries():
+def test_aggregate_daily_to_monthly_length():
+    """Two years of data → 24 monthly values."""
     date_strings = make_date_strings(2000, 2001)
     values = np.ones(len(date_strings))
-    result = compute_monthly_mean_std(values, date_strings, np.mean)
-    assert len(result) == 12
+    result = aggregate_daily_to_monthly(values, date_strings, np.mean)
+    assert len(result) == 24
 
 
-# ---------------------------------------------------------------------------
-# compute_monthly_mean_std — rain (sum aggregation)
-# ---------------------------------------------------------------------------
-
-def test_compute_monthly_mean_std_rain_known_values():
-    """
-    Two years, January daily rain values:
-    Year 1: 31 days × 2.0 mm → monthly sum = 62.0
-    Year 2: 31 days × 4.0 mm → monthly sum = 124.0
-    Expected: mean = 93.0, std = std([62, 124], ddof=1)
-    """
+def test_aggregate_daily_to_monthly_year_major_order():
+    """Values are in year-major order: Jan_y1, Feb_y1, ..., Dec_y1, Jan_y2, ..."""
     date_strings = make_date_strings(2000, 2001)
-
-    values = np.array([
-        2.0 if ds[:4] == "2000" else 4.0
-        for ds in date_strings
-    ])
-
-    result = compute_monthly_mean_std(values, date_strings, np.sum)
-
-    jan = result[0]
-    jan_sum_2000 = 2.0 * 31  # January has 31 days
-    jan_sum_2001 = 4.0 * 31
-    assert jan.mean == pytest.approx((jan_sum_2000 + jan_sum_2001) / 2)
-    assert jan.std  == pytest.approx(np.std([jan_sum_2000, jan_sum_2001], ddof=1))
+    # Year 2000 days = 1.0, Year 2001 days = 2.0
+    values = np.array([1.0 if ds[:4] == "2000" else 2.0 for ds in date_strings])
+    result = aggregate_daily_to_monthly(values, date_strings, np.mean)
+    # First 12 entries are 2000 (mean = 1.0), next 12 are 2001 (mean = 2.0)
+    assert np.all(result[:12] == pytest.approx(1.0))
+    assert np.all(result[12:] == pytest.approx(2.0))
 
 
-def test_compute_monthly_mean_std_single_year_std_is_zero():
-    """With only one year of data, std must be 0.0 (not NaN)."""
+def test_aggregate_daily_to_monthly_sum_aggregation():
+    """Sum aggregation: January 2000 with 31 days × 2.0 mm → 62.0."""
     date_strings = make_date_strings(2000, 2000)
-    values = np.ones(len(date_strings)) * 5.0
-    result = compute_monthly_mean_std(values, date_strings, np.mean)
-    for stats in result:
-        assert stats.std == pytest.approx(0.0)
-        assert not np.isnan(stats.std)
+    values = np.full(len(date_strings), 2.0)
+    result = aggregate_daily_to_monthly(values, date_strings, np.sum)
+    jan_sum = 2.0 * 31  # January has 31 days
+    assert result[0] == pytest.approx(jan_sum)
+
+
+# ---------------------------------------------------------------------------
+# get_climate_data — mocked API
+# ---------------------------------------------------------------------------
+
+def test_get_climate_data_returns_flat_arrays(monkeypatch):
+    """get_climate_data returns (temp, rain, evap) as flat arrays."""
+    import model.common.data_sources.climate as climate_mod
+
+    date_strings = make_date_strings(2000, 2001)
+    n_days = len(date_strings)
+    fake_response = {
+        "daily": {
+            "time": date_strings,
+            "temperature_2m_mean": [10.0] * n_days,
+            "rain_sum": [2.0] * n_days,
+            "et0_fao_evapotranspiration": [3.0] * n_days,
+        }
+    }
+    monkeypatch.setattr(climate_mod, "get_weather_forecast", lambda **kwargs: fake_response)
+
+    result = climate_mod.get_climate_data(latitude=0.0, longitude=0.0)
+
+    assert result is not None
+    temp, rain, evap = result
+    assert len(temp) == 24  # 2 years × 12 months
+    assert len(rain) == 24
+    assert len(evap) == 24
+
+
+def test_get_climate_data_year_major_ordering(monkeypatch):
+    """Temperature values appear in year-major order in the returned array."""
+    import model.common.data_sources.climate as climate_mod
+
+    date_strings = make_date_strings(2000, 2001)
+    n_days = len(date_strings)
+    values = [10.0 if ds[:4] == "2000" else 20.0 for ds in date_strings]
+    fake_response = {
+        "daily": {
+            "time": date_strings,
+            "temperature_2m_mean": values,
+            "rain_sum": [0.0] * n_days,
+            "et0_fao_evapotranspiration": [0.0] * n_days,
+        }
+    }
+    monkeypatch.setattr(climate_mod, "get_weather_forecast", lambda **kwargs: fake_response)
+
+    temp, _, _ = climate_mod.get_climate_data(latitude=0.0, longitude=0.0)
+
+    assert np.all(temp[:12] == pytest.approx(10.0))
+    assert np.all(temp[12:] == pytest.approx(20.0))
+
+
+def test_get_climate_data_returns_none_on_api_failure(monkeypatch):
+    """get_climate_data returns None when the API call fails."""
+    import model.common.data_sources.climate as climate_mod
+
+    monkeypatch.setattr(climate_mod, "get_weather_forecast", lambda **kwargs: None)
+
+    result = climate_mod.get_climate_data(latitude=0.0, longitude=0.0)
+    assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/shamba/tests/test_integration_split_file.py
+++ b/shamba/tests/test_integration_split_file.py
@@ -137,7 +137,8 @@ def test_split_file_full_run_matches_single_row(tmp_path, monkeypatch):
     inverse_model = InverseSoilModule.get_soil_model(SoilModelType.ROTH_C)
 
     common_kwargs = dict(
-        n_cohorts=N_COHORTS,
+        n_proj_cohorts=N_COHORTS,
+        n_base_cohorts=N_COHORTS,
         plot_index=0,
         allometry=ALLOMETRIC_KEYS,
         use_climate_api=False,

--- a/shamba/tests/test_integration_split_file.py
+++ b/shamba/tests/test_integration_split_file.py
@@ -140,7 +140,8 @@ def test_split_file_full_run_matches_single_row(tmp_path, monkeypatch):
         n_cohorts=N_COHORTS,
         plot_index=0,
         allometry=ALLOMETRIC_KEYS,
-        use_api=False,
+        use_climate_api=False,
+        use_soil_api=False,
         create_forward_soil_model=forward_model.create,
         create_inverse_soil_model=inverse_model.create,
     )

--- a/shamba/tests/test_integration_split_file.py
+++ b/shamba/tests/test_integration_split_file.py
@@ -25,6 +25,9 @@ from model.common.data_handler import (
 import model.soil_models.forward_soil_model as ForwardSoilModule
 import model.soil_models.inverse_soil_model as InverseSoilModule
 from model.soil_models.soil_model_types import SoilModelType
+import model.climate as Climate
+import model.soil_params as SoilParams
+
 
 FIXTURES_DIR = os.path.join(configuration.TESTS_DIR, "fixtures")
 WL_SINGLE_ROW = os.path.join(FIXTURES_DIR, "WL_input.csv")
@@ -136,13 +139,24 @@ def test_split_file_full_run_matches_single_row(tmp_path, monkeypatch):
     forward_model = ForwardSoilModule.get_soil_model(SoilModelType.ROTH_C)
     inverse_model = InverseSoilModule.get_soil_model(SoilModelType.ROTH_C)
 
+    climate = Climate.from_location(
+        location=(scalar["lat"].item(), scalar["lon"].item()),
+        use_climate_api=False,
+    )
+    soil = SoilParams.get_soil_params(
+        location=(scalar["lat"].item(), scalar["lon"].item()),
+        use_soil_api=False,
+        plot_id=0,
+        plot_index=0,
+    )
+
     common_kwargs = dict(
+        climate = climate,
+        soil = soil,
         n_proj_cohorts=N_COHORTS,
         n_base_cohorts=N_COHORTS,
         plot_index=0,
         allometry=ALLOMETRIC_KEYS,
-        use_climate_api=False,
-        use_soil_api=False,
         create_forward_soil_model=forward_model.create,
         create_inverse_soil_model=inverse_model.create,
     )

--- a/shamba/tests/test_runner.py
+++ b/shamba/tests/test_runner.py
@@ -2,8 +2,7 @@
 
 Covers:
 - run_monte_carlo returns a list of length n_samples
-- When no distribution_dict and zero climate/soil uncertainty, all results are identical
-- handle_intervention is called with soil_override set (not None) on every call
+- When no distribution_dict, every handle_intervention call receives identical inputs
 - summarise_mc_results: correct column names, array shapes, and numeric values
 - write_mc_summary_csv: produces a readable CSV with correct headers and year column
 """
@@ -117,8 +116,8 @@ def test_run_monte_carlo_returns_n_samples():
 
 
 def test_run_monte_carlo_deterministic_no_distributions():
-    """With no distributions and zero soil/climate uncertainty, every call to
-    handle_intervention receives identical inputs."""
+    """With no distribution_dict, every call to handle_intervention receives
+    identical intervention_input dicts."""
     captured_inputs = []
 
     def capture(**kwargs):
@@ -150,29 +149,6 @@ def test_run_monte_carlo_deterministic_no_distributions():
                 np.asarray(subsequent[key]),
                 err_msg=f"Input '{key}' differs between samples despite zero uncertainty",
             )
-
-
-def test_run_monte_carlo_uses_soil():
-    """handle_intervention is called with soil set (not None) on every call."""
-    with patch("model.monte_carlo.runner.handle_intervention", return_value=FIXED_RESULT) as mock_handle, \
-         patch("model.monte_carlo.runner.concurrent.futures.ProcessPoolExecutor", _InProcessExecutor):
-        run_monte_carlo(
-            base_input_dict=BASE_INPUT,
-            soil_params=FakeSoilParams(),
-            climate=FakeClimateData(),
-            n_samples=3,
-            create_forward_soil_model=fake_forward,
-            create_inverse_soil_model=fake_inverse,
-            n_proj_cohorts=1,
-            n_base_cohorts=1,
-            plot_index=0,
-            seed=0,
-        )
-
-    assert mock_handle.call_count == 3
-    for call in mock_handle.call_args_list:
-        soil = call.kwargs.get("soil")
-        assert soil is not None, "soil should be set on every call"
 
 
 # ---------------------------------------------------------------------------

--- a/shamba/tests/test_runner.py
+++ b/shamba/tests/test_runner.py
@@ -152,8 +152,8 @@ def test_run_monte_carlo_deterministic_no_distributions():
             )
 
 
-def test_run_monte_carlo_uses_soil_override():
-    """handle_intervention is called with soil_override set (not None) on every call."""
+def test_run_monte_carlo_uses_soil():
+    """handle_intervention is called with soil set (not None) on every call."""
     with patch("model.monte_carlo.runner.handle_intervention", return_value=FIXED_RESULT) as mock_handle, \
          patch("model.monte_carlo.runner.concurrent.futures.ProcessPoolExecutor", _InProcessExecutor):
         run_monte_carlo(
@@ -171,8 +171,8 @@ def test_run_monte_carlo_uses_soil_override():
 
     assert mock_handle.call_count == 3
     for call in mock_handle.call_args_list:
-        soil_override = call.kwargs.get("soil_override")
-        assert soil_override is not None, "soil_override should be set on every call"
+        soil = call.kwargs.get("soil")
+        assert soil is not None, "soil should be set on every call"
 
 
 # ---------------------------------------------------------------------------

--- a/shamba/tests/test_runner.py
+++ b/shamba/tests/test_runner.py
@@ -108,7 +108,8 @@ def test_run_monte_carlo_returns_n_samples():
             n_samples=5,
             create_forward_soil_model=fake_forward,
             create_inverse_soil_model=fake_inverse,
-            n_cohorts=1,
+            n_proj_cohorts=1,
+            n_base_cohorts=1,
             plot_index=0,
             seed=0,
         )
@@ -133,7 +134,8 @@ def test_run_monte_carlo_deterministic_no_distributions():
             n_samples=4,
             create_forward_soil_model=fake_forward,
             create_inverse_soil_model=fake_inverse,
-            n_cohorts=1,
+            n_proj_cohorts=1,
+            n_base_cohorts=1,
             plot_index=0,
             seed=42,
         )
@@ -161,7 +163,8 @@ def test_run_monte_carlo_uses_soil_override():
             n_samples=3,
             create_forward_soil_model=fake_forward,
             create_inverse_soil_model=fake_inverse,
-            n_cohorts=1,
+            n_proj_cohorts=1,
+            n_base_cohorts=1,
             plot_index=0,
             seed=0,
         )

--- a/shamba/tests/test_sampler.py
+++ b/shamba/tests/test_sampler.py
@@ -330,9 +330,9 @@ def test_sample_climate_params_zero_std():
     samples = sample_climate_params(climate, n_samples=10, rng=rng)
     assert len(samples) == 10
     for s in samples:
-        np.testing.assert_array_equal(s["temp"], climate.temperature)
-        np.testing.assert_array_equal(s["rain"], climate.rain)
-        np.testing.assert_array_equal(s["evap"], climate.evaporation)
+        np.testing.assert_array_equal(s.temperature, climate.temperature)
+        np.testing.assert_array_equal(s.rain, climate.rain)
+        np.testing.assert_array_equal(s.evaporation, climate.evaporation)
 
 
 # ---------------------------------------------------------------------------
@@ -351,7 +351,7 @@ def test_sample_climate_params_nonzero_std():
     )
     rng = np.random.default_rng(4)
     samples = sample_climate_params(climate, n_samples=1000, rng=rng)
-    temp_vals = np.array([s["temp"][0] for s in samples])
+    temp_vals = np.array([s.temperature[0] for s in samples])
     assert np.mean(temp_vals) == pytest.approx(20.0, abs=0.3)
     assert np.std(temp_vals)  == pytest.approx(2.0,  rel=0.15)
 
@@ -366,7 +366,7 @@ def test_sample_climate_params_rain_clipped():
     )
     rng = np.random.default_rng(5)
     samples = sample_climate_params(climate, n_samples=200, rng=rng)
-    assert all(np.all(s["rain"] >= 0.0) for s in samples)
+    assert all(np.all(s.rain >= 0.0) for s in samples)
 
 
 def test_sample_climate_params_evap_clipped():
@@ -379,7 +379,7 @@ def test_sample_climate_params_evap_clipped():
     )
     rng = np.random.default_rng(6)
     samples = sample_climate_params(climate, n_samples=200, rng=rng)
-    assert all(np.all(s["evap"] >= 0.0) for s in samples)
+    assert all(np.all(s.evaporation >= 0.0) for s in samples)
 
 
 # ---------------------------------------------------------------------------

--- a/shamba/tests/test_tree_emissions.py
+++ b/shamba/tests/test_tree_emissions.py
@@ -114,7 +114,7 @@ WL_expected_project_emissions = [5.476539,
 ]
 
 TESTB_N_COHORTS = 1
-testB_allometric_keys = ["chave dry","chave dry", "ryan", "markhamia"]
+testB_allometric_keys = ["chave dry", "chave dry"]
 # TODO: confirm testB_expected_base_emissions against the SHAMBA Excel reference model.
 # Values were calculated separately from the code but have not yet been verified in Excel.
 # This is the highest-priority independent check needed for the tree sub-model.
@@ -253,7 +253,7 @@ def test_tree_model(csv_input_file, N_COHORTS, allometric_keys, expected_base_em
     ])
 
     tree_base = TreeModel.from_defaults(
-        tree_params=tree_params_1,
+        tree_params=tree_par_base,
         tree_growth=growth_base,
         year_planted=0,
         stand_density=int(scalar_input_data["base_plant_dens1"][0]),
@@ -292,6 +292,7 @@ def test_tree_model(csv_input_file, N_COHORTS, allometric_keys, expected_base_em
         mortality_fractions_project=mortality_fractions_project,
         no_of_years=N_YEARS,
         cohort_count=N_COHORTS,
+        type="proj",
     )
 
     tree_base_emissions = Emit.create(
@@ -350,6 +351,7 @@ def test_create_tree_projects_uses_per_cohort_thinning():
         mortality_fractions_project=[fraction, fraction],
         no_of_years=N_YEARS,
         cohort_count=2,
+        type="proj",
     )
 
     assert tree_projects[0].thinning[0] != tree_projects[1].thinning[0], (
@@ -357,6 +359,58 @@ def test_create_tree_projects_uses_per_cohort_thinning():
     )
     np.testing.assert_array_equal(tree_projects[0].thinning, thinning_cohort1)
     np.testing.assert_array_equal(tree_projects[1].thinning, thinning_cohort2)
+
+def test_create_tree_baselines_uses_per_cohort_thinning():
+    """Each baseline cohort must receive its own thinning array, not a shared one."""
+    file_path = os.path.join(configuration.TESTS_DIR, "fixtures", "WL_input.csv")
+    scalar_input_data, tree_size_data, mgmt_input_data, _ = expand_single_row_data_input(file_path)
+    N_YEARS = int(scalar_input_data["yrs_proj"].item())
+
+    # Build a two-cohort scenario reusing WL species for both cohorts.
+    # create_tree_params_from_species_index reads "species{N}";
+    # create_tree_growths reads "proj_species{N}" at allometric_keys[N] (index 0 = base).
+    growth_input = {
+        **scalar_input_data,
+        **tree_size_data,
+        "species1": scalar_input_data["base_species1"],
+        "species2": scalar_input_data["base_species1"],
+        "proj_species2": scalar_input_data["base_species1"],
+        "proj_plant_yr2": scalar_input_data["base_plant_yr1"],
+        "proj_plant_dens2": scalar_input_data["base_plant_dens1"],
+    }
+    tree_params = TreeParams.create_tree_params_from_species_index(growth_input, 2)
+    tree_growths = TreeGrowth.create_tree_growths(
+        growth_input, tree_params, ["chave dry", "chave dry", "chave dry"], 2
+    )
+
+    thinning_cohort1 = mgmt_input_data["thin_proj_cohort1"].copy()
+    thinning_cohort2 = mgmt_input_data["thin_proj_cohort1"].copy()
+    # Give cohort 2 a different thinning value at year 0 so the arrays are distinguishable.
+    thinning_cohort2[0] = 0.99
+
+    fraction = np.array([1, 0.0, 0.0, 1, 1])
+
+    tree_baselines = TreeModel.create_tree_projects(
+        csv_input_data=growth_input,
+        tree_params=tree_params,
+        growths=tree_growths,
+        thinnings_project=[thinning_cohort1, thinning_cohort2],
+        thinning_fractions_project=[fraction, fraction],
+        mortalities_project=[
+            mgmt_input_data["mort_proj_cohort1"],
+            mgmt_input_data["mort_proj_cohort1"],
+        ],
+        mortality_fractions_project=[fraction, fraction],
+        no_of_years=N_YEARS,
+        cohort_count=2,
+        type="proj",
+    )
+
+    assert tree_baselines[0].thinning[0] != tree_baselines[1].thinning[0], (
+        "Cohort 1 and cohort 2 should have different thinning arrays"
+    )
+    np.testing.assert_array_equal(tree_baselines[0].thinning, thinning_cohort1)
+    np.testing.assert_array_equal(tree_baselines[1].thinning, thinning_cohort2)
 
 
 def test_validation_requires_per_cohort_thinning_when_second_cohort_present():


### PR DESCRIPTION
## Summary

Establishes a clear four-stage data pipeline (import/validate → save → sample → run) across the CLI, eliminating duplicated fetch logic and making `handle_intervention()` a pure calculation.

### Key changes
- Split `use-api` into `use-soil-api` and `use-climate-api` for greater flexibility
- Support multi-cohort baselines
- Unify all three climate data paths through `from_vectors()`; `ClimateStats` and `compute_monthly_mean_std` removed; `get_climate_data()` now returns flat `(temp, rain, evap)` arrays; `aggregate_daily_to_monthly()` replaces `compute_monthly_mean_std`
- `handle_intervention()` is a pure calculation; `climate` and `soil` data are required parameters. Removed: `use_climate_api`, `use_soil_api`, `soil_override`, `location`, `plot_id`, internal API/CSV fetches, and the defunct `inverse_climate` averaging block 
- N_YEARS vs N_YEARS+1 indexing convention made explicit via comments (no behaviour change)
- `shamba_command_line.py` — fetches climate and soil once before the MC/deterministic split; validated-input CSVs written in the shared section (MC runs now produce them too)
- MC runner carries `ClimateData` directly; rather than temporarily adding them to the general input data to be unpacked in `handle_intervention()`. `SampleArgs` loses API flags, gains `climate: ClimateData`; climate injection loop removed; `sample_climate_params()` returns `List[ClimateData]` so that data can be used without conversion
