### PR TITLE
Expand sampling scope

### DIFF
--- a/shamba/model/common/calculate_emissions.py
+++ b/shamba/model/common/calculate_emissions.py
@@ -52,11 +52,9 @@ def get_tree_model_data(
     no_of_base_cohorts: int,
     no_of_proj_cohorts: int,
     allometry: List[str],
+    tree_species_data: Dict[int, Dict],
+    pool_species_data: Dict[int, Dict],
 ) -> GetTreeModelReturnData:
-    # Load each species-lookup csv once per run, rather than once per cohort.
-    tree_species_data = TreeParams.load_tree_species_data()
-    pool_species_data = TreeModel.load_biomass_pool_species_data()
-
     # Tree params: read species codes directly from vector-format keys
     base_tree_params = [
         TreeParams.from_species_index(
@@ -228,13 +226,12 @@ class GetCropModelReturnData(NamedTuple):
 
 
 def get_crop_model_data(
-    intervention_input: Dict[str, Union[float, int]], no_of_years: int
+    intervention_input: Dict[str, Union[float, int]],
+    no_of_years: int,
+    crop_species_data: Dict[int, Dict],
 ) -> GetCropModelReturnData:
     n_crop_base = sum(1 for i in range(1, 100) if f"crop_base_spp{i}" in intervention_input)
     n_crop_proj = sum(1 for i in range(1, 100) if f"crop_proj_spp{i}" in intervention_input)
-
-    # Load the crop species csv once for the whole run, rather than once per cohort.
-    crop_species_data = CropParams.load_crop_species_data()
 
     crop_base, crop_par_base = CropModel.get_crop_bases(
         input_data=intervention_input,
@@ -590,6 +587,9 @@ def handle_intervention(
     n_proj_cohorts: int,
     n_base_cohorts: int,
     plot_index: int,
+    tree_species_data: Dict[int, Dict],
+    crop_species_data: Dict[int, Dict],
+    pool_species_data: Dict[int, Dict],
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY,
     gwp: dict = CONSTANTS.GWP_list[CONSTANTS.DEFAULT_GWP],
     emission_factors: Emit.EmissionFactors = Emit.EmissionFactors()
@@ -608,6 +608,7 @@ def handle_intervention(
     crop_model_data = get_crop_model_data(
         no_of_years=no_of_years,
         intervention_input=intervention_input,
+        crop_species_data=crop_species_data,
     )
 
     fire_model_data = get_fire_model_data(
@@ -624,7 +625,9 @@ def handle_intervention(
         intervention_input=intervention_input,
         no_of_base_cohorts=n_base_cohorts,
         no_of_proj_cohorts=n_proj_cohorts,
-        allometry=allometry
+        allometry=allometry,
+        tree_species_data=tree_species_data,
+        pool_species_data=pool_species_data,
     )
 
     # ----------

--- a/shamba/model/common/calculate_emissions.py
+++ b/shamba/model/common/calculate_emissions.py
@@ -20,6 +20,7 @@ from model.soil_models.soil_model_types import (
     ForwardSoilModelData,
     InverseSoilModelData,
 )
+from model.soil_models.soil_model_params import SoilModelParams
 
 def _extract_scalar(val: Any) -> Any:
     if isinstance(val, np.ndarray):
@@ -299,7 +300,13 @@ def get_soil_carbon_data(
     cover_proj: np.ndarray,
     create_forward_soil_model,
     create_inverse_soil_model,
+    soil_model_params: Optional[SoilModelParams] = None,
 ) -> GetSoilCarbonReturnData:
+    # **soil_model_kwargs omits the keyword entirely when unset, so the soil model's own default applies.
+    soil_model_kwargs = (
+        {"soil_model_params": soil_model_params} if soil_model_params is not None else {}
+    )
+
     # Solve to y=0
     for_soil = create_forward_soil_model(
         soil,
@@ -310,6 +317,7 @@ def get_soil_carbon_data(
         crop=crop_base,
         fire=fire_base,
         solve_to_value=True,
+        **soil_model_kwargs,
     )
 
     # Soil carbon for baseline and project
@@ -323,6 +331,7 @@ def get_soil_carbon_data(
         tree=tree_base,
         litter=[litter_external_base],
         fire=fire_base,
+        **soil_model_kwargs,
     )
 
     project_forward_soil_data = create_forward_soil_model(
@@ -335,6 +344,7 @@ def get_soil_carbon_data(
         tree=tree_projects,
         litter=[litter_external_project],
         fire=fire_project,
+        **soil_model_kwargs,
     )
 
     return GetSoilCarbonReturnData(
@@ -612,15 +622,21 @@ def handle_intervention(
     pool_species_data: Dict[int, Dict],
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY,
     gwp: dict = CONSTANTS.GWP_list[CONSTANTS.DEFAULT_GWP],
-    emission_factors: Emit.EmissionFactors = Emit.EmissionFactors()
+    emission_factors: Emit.EmissionFactors = Emit.EmissionFactors(),
+    soil_model_params: Optional[SoilModelParams] = None,
 ):
     no_of_years = get_int(CONSTANTS.NO_OF_YEARS_KEY, intervention_input)
+
+    # **soil_model_kwargs omits the keyword entirely when unset, so the soil model's own default applies.
+    soil_model_kwargs = (
+        {"soil_model_params": soil_model_params} if soil_model_params is not None else {}
+    )
 
     # ----------
     # SOIL EQUILIBRIUM SOLVE
     # ----------
 
-    inverse_soil_model = create_inverse_soil_model(soil, climate)
+    inverse_soil_model = create_inverse_soil_model(soil, climate, **soil_model_kwargs)
 
     # ----------
     # MODEL DATA
@@ -722,6 +738,7 @@ def handle_intervention(
         cover_proj=intervention_input["proj_cover"],
         create_forward_soil_model=create_forward_soil_model,
         create_inverse_soil_model=create_inverse_soil_model,
+        soil_model_params=soil_model_params,
     )
 
     emissions = get_emissions_data(

--- a/shamba/model/common/calculate_emissions.py
+++ b/shamba/model/common/calculate_emissions.py
@@ -80,16 +80,33 @@ def get_tree_model_data(
     )
 
     # Thinning and mortality: read pre-built vectors directly from input.
+    # Branch/stem fractions are required mgmt input. Leaf/croot/froot fractions
+    # are optional mgmt input — if the column is omitted, the species default
+    # from biomass_pool_params.csv is used instead.
+    def pool_fraction(key: str, species_default: float) -> float:
+        if key in intervention_input:
+            return float(np.atleast_1d(intervention_input[key])[0])
+        return species_default
+
+    base_pool_data = [
+        TreeModel.get_species_pool_data(base_tree_params[i].species, pool_species_data)
+        for i in range(no_of_base_cohorts)
+    ]
+    proj_pool_data = [
+        TreeModel.get_species_pool_data(proj_tree_params[i].species, pool_species_data)
+        for i in range(no_of_proj_cohorts)
+    ]
 
     thinnings_base = [
         intervention_input[f"thin_base_cohort{i + 1}"] for i in range(no_of_base_cohorts)
     ]
     thinning_fractions_left_base = [
         np.array([
-            1,
+            pool_fraction(f"thin_base_leaf_cohort{i + 1}", base_pool_data[i]["thinning_fraction"][0]),
             float(np.atleast_1d(intervention_input[f"thin_base_br_cohort{i + 1}"])[0]),
             float(np.atleast_1d(intervention_input[f"thin_base_st_cohort{i + 1}"])[0]),
-            1, 1,
+            pool_fraction(f"thin_base_croot_cohort{i + 1}", base_pool_data[i]["thinning_fraction"][3]),
+            pool_fraction(f"thin_base_froot_cohort{i + 1}", base_pool_data[i]["thinning_fraction"][4]),
         ])
         for i in range(no_of_base_cohorts)
     ]
@@ -98,10 +115,11 @@ def get_tree_model_data(
     ]
     mortality_fractions_left_base = [
         np.array([
-            1,
+            pool_fraction(f"mort_base_leaf_cohort{i + 1}", base_pool_data[i]["mortality_fraction"][0]),
             float(np.atleast_1d(intervention_input[f"mort_base_br_cohort{i + 1}"])[0]),
             float(np.atleast_1d(intervention_input[f"mort_base_st_cohort{i + 1}"])[0]),
-            1, 1,
+            pool_fraction(f"mort_base_croot_cohort{i + 1}", base_pool_data[i]["mortality_fraction"][3]),
+            pool_fraction(f"mort_base_froot_cohort{i + 1}", base_pool_data[i]["mortality_fraction"][4]),
         ])
         for i in range(no_of_base_cohorts)
     ]
@@ -111,10 +129,11 @@ def get_tree_model_data(
     ]
     thinning_fractions_project = [
         np.array([
-            1,
+            pool_fraction(f"thin_proj_leaf_cohort{i + 1}", proj_pool_data[i]["thinning_fraction"][0]),
             float(np.atleast_1d(intervention_input[f"thin_proj_br_cohort{i + 1}"])[0]),
             float(np.atleast_1d(intervention_input[f"thin_proj_st_cohort{i + 1}"])[0]),
-            1, 1,
+            pool_fraction(f"thin_proj_croot_cohort{i + 1}", proj_pool_data[i]["thinning_fraction"][3]),
+            pool_fraction(f"thin_proj_froot_cohort{i + 1}", proj_pool_data[i]["thinning_fraction"][4]),
         ])
         for i in range(no_of_proj_cohorts)
     ]
@@ -123,10 +142,11 @@ def get_tree_model_data(
     ]
     mortality_fractions_project = [
         np.array([
-            1,
+            pool_fraction(f"mort_proj_leaf_cohort{i + 1}", proj_pool_data[i]["mortality_fraction"][0]),
             float(np.atleast_1d(intervention_input[f"mort_proj_br_cohort{i + 1}"])[0]),
             float(np.atleast_1d(intervention_input[f"mort_proj_st_cohort{i + 1}"])[0]),
-            1, 1,
+            pool_fraction(f"mort_proj_croot_cohort{i + 1}", proj_pool_data[i]["mortality_fraction"][3]),
+            pool_fraction(f"mort_proj_froot_cohort{i + 1}", proj_pool_data[i]["mortality_fraction"][4]),
         ])
         for i in range(no_of_proj_cohorts)
     ]

--- a/shamba/model/common/data_handler.py
+++ b/shamba/model/common/data_handler.py
@@ -65,12 +65,17 @@ COHORT_HEADER_DATATYPE_PATTERNS = {
     # Thinning percents by cohort index
     r"^thin_(base|proj)_cohort": "proportion",
 
-    # Thinning fractions by pool, cohort index embedded
+    # Thinning fractions by pool, cohort index embedded. Branch/stem are
+    # required (see REQUIRED_MGMT_KEYS / GROUPED_HEADER_VALIDATIONS below).
+    # Leaf/croot/froot are optional — if omitted, the species default from
+    # biomass_pool_params.csv is used instead (see calculate_emissions.py).
     r"^thin_(base|proj)_(br|st)_cohort": "proportion",
+    r"^thin_(base|proj)_(leaf|croot|froot)_cohort": "proportion",
 
     # Mortality by cohort — keys use the form mort_{base|proj}_cohort{n}
     r"^mort_(base|proj)_cohort": "proportion",
     r"^mort_(base|proj)_(br|st)_cohort": "proportion",
+    r"^mort_(base|proj)_(leaf|croot|froot)_cohort": "proportion",
 }
 
 FERT_HEADER_DATATYPE_PATTERNS = {

--- a/shamba/model/common/io_handler.py
+++ b/shamba/model/common/io_handler.py
@@ -135,6 +135,12 @@ source directory, and be named:
       thin_proj_cohortN, thin_proj_br_cohortN, thin_proj_st_cohortN
       mort_proj_cohortN, mort_proj_br_cohortN, mort_proj_st_cohortN
 
+    Optional thinning/mortality fraction columns for leaf, coarse root and fine root
+    (per cohort, base or proj as above):
+      thin_(base|proj)_leaf_cohortN, thin_(base|proj)_croot_cohortN, thin_(base|proj)_froot_cohortN
+      mort_(base|proj)_leaf_cohortN, mort_(base|proj)_croot_cohortN, mort_(base|proj)_froot_cohortN
+    If omitted, the species default from biomass_pool_params.csv is used instead.
+
     Note: the single-row input format applies the same thinning and mortality
     schedule to all project cohorts. Use the split-file format to specify
     different thinning schedules per cohort.

--- a/shamba/model/crop_model.py
+++ b/shamba/model/crop_model.py
@@ -12,7 +12,6 @@ from .common_schema import OutputSchema as ClimateDataOutputSchema
 from .crop_params import (
     CropParamsData,
     CropParamsSchema,
-    load_crop_species_data,
 )
 import model.common.constants as CONSTANTS
 from .crop_params import from_species_index as create_crop_params_from_species_index
@@ -121,10 +120,8 @@ def save(crop_model, file="crop_model.csv"):
 
 
 def get_crop_models_and_crop_params(
-    input_data, no_of_years, start_index, end_index, crop_getter, species_data=None
+    input_data, no_of_years, start_index, end_index, crop_getter, species_data
 ):
-    # Load the crop species csv once for the whole range, rather than once per cohort.
-    species_data = species_data if species_data is not None else load_crop_species_data()
     results = [
         crop_getter(input_data, no_of_years, index, species_data)
         for index in range(start_index, end_index + 1)
@@ -138,7 +135,7 @@ def get_crop_models_and_crop_params(
 
 
 def get_crop_bases(
-    input_data, no_of_years, start_index, end_index, species_data=None
+    input_data, no_of_years, start_index, end_index, species_data
 ) -> Tuple[List[CropModelData], List[CropParamsData]]:
     return get_crop_models_and_crop_params(
         input_data, no_of_years, start_index, end_index, get_crop_base, species_data
@@ -146,7 +143,7 @@ def get_crop_bases(
 
 
 def get_crop_projects(
-    input_data, no_of_years, start_index, end_index, species_data=None
+    input_data, no_of_years, start_index, end_index, species_data
 ) -> Tuple[List[CropModelData], List[CropParamsData]]:
     return get_crop_models_and_crop_params(
         input_data, no_of_years, start_index, end_index, get_crop_project, species_data
@@ -154,7 +151,7 @@ def get_crop_projects(
 
 
 def get_crop_data(
-    input_data, no_of_years, prefix, index, species_data=None
+    input_data, no_of_years, prefix, index, species_data
 ) -> Tuple[CropModelData, CropParamsData]:
     scenario = "baseline" if "base" in prefix else "project"
     try:
@@ -179,12 +176,12 @@ def get_crop_data(
 
 
 def get_crop_base(
-    input_data, no_of_years, index, species_data=None
+    input_data, no_of_years, index, species_data
 ) -> Tuple[CropModelData, CropParamsData]:
     return get_crop_data(input_data, no_of_years, "crop_base", index, species_data)
 
 
 def get_crop_project(
-    input_data, no_of_years, index, species_data=None
+    input_data, no_of_years, index, species_data
 ) -> Tuple[CropModelData, CropParamsData]:
     return get_crop_data(input_data, no_of_years, "crop_proj", index, species_data)

--- a/shamba/model/crop_params.py
+++ b/shamba/model/crop_params.py
@@ -18,10 +18,11 @@ CROP_SPECIES_PARAM_FIELDS = (
     "carbon_below", "carbon_above", "root_to_shoot",
 )
 
-# Keys are prefixed with the catalog name ("crop_") rather than bare field names,
-# since some fields (e.g. root_to_shoot) also exist on other species catalogs
-# (tree_params.csv) with independently-numbered species codes — a bare key would
-# be ambiguous between "crop species 3" and "tree species 3".
+# Keys are prefixed with the species-lookup table name ("crop_") rather than bare
+# field names, since some fields (e.g. root_to_shoot) also exist in other
+# species-lookup tables (tree_params.csv) with independently-numbered species
+# codes — a bare key would be ambiguous between "crop species 3" and "tree
+# species 3".
 # Matches MC distribution keys for per-species crop parameter sampling, e.g.
 # "crop_slope_sp2", "crop_root_to_shoot_sp1".
 CROP_SPECIES_DIST_KEY_PATTERN = re.compile(

--- a/shamba/model/crop_params.py
+++ b/shamba/model/crop_params.py
@@ -141,14 +141,13 @@ class CropParamsSchema(Schema):
         return CropParamsData(**data)
 
 
-def from_species_index(index, species_data: dict = None) -> CropParamsData:
+def from_species_index(index, species_data: dict) -> CropParamsData:
     """Construct Crop object from its species code (Sc column in crop_params.csv).
 
     Args:
         index: species code to look up
         species_data: pre-loaded species data (as returned by
-            load_crop_species_data()), to avoid re-reading the csv from disk
-            once per cohort. If not given, loads it fresh.
+            load_crop_species_data()), loaded once per run by the caller.
     Return:
         Crop object
     Raises:
@@ -156,7 +155,6 @@ def from_species_index(index, species_data: dict = None) -> CropParamsData:
 
     """
     index = int(index)
-    species_data = species_data if species_data is not None else load_crop_species_data()
     if index not in species_data:
         raise KeyError(
             f"No crop species with code {index} found in crop_params.csv "

--- a/shamba/model/crop_params.py
+++ b/shamba/model/crop_params.py
@@ -2,6 +2,7 @@
 
 
 import logging as log
+import re
 import sys
 
 import numpy as np
@@ -9,6 +10,23 @@ from marshmallow import Schema, fields, post_load
 
 from model.common import csv_handler
 import model.common.constants as CONSTANTS
+
+# Per-species fields eligible for MC distribution sampling — the single source of
+# truth for both the key-matching pattern below and sampler.sample_species_params().
+CROP_SPECIES_PARAM_FIELDS = (
+    "slope", "intercept", "nitrogen_below", "nitrogen_above",
+    "carbon_below", "carbon_above", "root_to_shoot",
+)
+
+# Keys are prefixed with the catalog name ("crop_") rather than bare field names,
+# since some fields (e.g. root_to_shoot) also exist on other species catalogs
+# (tree_params.csv) with independently-numbered species codes — a bare key would
+# be ambiguous between "crop species 3" and "tree species 3".
+# Matches MC distribution keys for per-species crop parameter sampling, e.g.
+# "crop_slope_sp2", "crop_root_to_shoot_sp1".
+CROP_SPECIES_DIST_KEY_PATTERN = re.compile(
+    rf"^crop_({'|'.join(CROP_SPECIES_PARAM_FIELDS)})_sp(\d+)$"
+)
 
 # --------------------------
 # Read species data from csv

--- a/shamba/model/monte_carlo/distribution_handler.py
+++ b/shamba/model/monte_carlo/distribution_handler.py
@@ -6,6 +6,11 @@ from typing import Dict, List, Optional, NamedTuple
 import numpy as np
 import pandas as pd
 
+from model.tree_params import TREE_SPECIES_DIST_KEY_PATTERN
+from model.crop_params import CROP_SPECIES_DIST_KEY_PATTERN
+from model.tree_model import BIOMASS_POOL_DIST_KEY_PATTERN
+from model.soil_models.soil_model_params import ROTH_C_DIST_KEYS
+
 
 SUPPORTED_DISTRIBUTIONS = frozenset({
     "normal",
@@ -73,6 +78,22 @@ def _parse_float(value, label: str, errors: list) -> Optional[float]:
         return None
 
 
+def _is_soil_model_or_species_parameter(parameter: str) -> bool:
+    """True for roth_c_{field}/tree_{field}_sp{N}/crop_{field}_sp{N}/pool_{field}_sp{N} keys.
+
+    These are not looked up in base_input_dict — runner.py's
+    _partition_distributions() routes them to sample_soil_model_params() or
+    sample_species_params() instead, each checking its own base values
+    (RothCParams()/the relevant species-lookup table) at draw time.
+    """
+    return (
+        parameter in ROTH_C_DIST_KEYS
+        or bool(TREE_SPECIES_DIST_KEY_PATTERN.match(parameter))
+        or bool(CROP_SPECIES_DIST_KEY_PATTERN.match(parameter))
+        or bool(BIOMASS_POOL_DIST_KEY_PATTERN.match(parameter))
+    )
+
+
 def load_distributions(
     path: str,
     base_input_dict: Dict,
@@ -132,7 +153,7 @@ def load_distributions(
         row_errors: List[str] = []
 
         # --- Validate parameter name first — skip remaining checks if unknown ---
-        if parameter not in base_input_dict:
+        if parameter not in base_input_dict and not _is_soil_model_or_species_parameter(parameter):
             all_errors.append(
                 f"{row_label}: '{parameter}' is not a recognised input parameter."
             )

--- a/shamba/model/monte_carlo/runner.py
+++ b/shamba/model/monte_carlo/runner.py
@@ -14,6 +14,7 @@ from model.climate import ClimateData
 from model.tree_params import TREE_SPECIES_PARAM_FIELDS, TREE_SPECIES_DIST_KEY_PATTERN
 from model.crop_params import CROP_SPECIES_PARAM_FIELDS, CROP_SPECIES_DIST_KEY_PATTERN
 from model.tree_model import BIOMASS_POOL_PARAM_FIELDS, BIOMASS_POOL_DIST_KEY_PATTERN
+from model.soil_models.soil_model_params import RothCParams, SoilModelParams, ROTH_C_DIST_KEYS
 
 class MCSummaries(NamedTuple):
     base: Dict[str, np.ndarray]
@@ -32,6 +33,7 @@ class SampleArgs(NamedTuple):
     tree_species_data: Dict[int, Dict]
     crop_species_data: Dict[int, Dict]
     pool_species_data: Dict[int, Dict]
+    soil_model_params: Optional[SoilModelParams] = None
     emission_factors: EmissionFactors = EmissionFactors()
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY
     gwp: dict = CONSTANTS.GWP_list[CONSTANTS.DEFAULT_GWP]
@@ -45,22 +47,29 @@ def _partition_distributions(
     Dict[str, DistributionSpec],
     Dict[str, DistributionSpec],
     Dict[str, DistributionSpec],
+    Dict[str, DistributionSpec],
 ]:
     """Split a user distributions dict by key pattern.
 
-    Species-lookup entries (tree_*_sp{N}, crop_*_sp{N}, pool_*_sp{N}) route to
-    sample_species_params() for their own species-lookup table; everything else
-    falls through to draw_samples() against the flat intervention-input dict,
-    which does a direct dict lookup per key and would raise a KeyError on a
-    species key, which has a different dict shape.
+    RothC entries (roth_c_{field}, matching RothCParams._fields) route to
+    sample_soil_model_params(). Species-lookup entries (tree_*_sp{N}, crop_*_sp{N},
+    pool_*_sp{N}) route to sample_species_params() for their own species-lookup
+    table; everything else falls through to draw_samples() against the flat
+    intervention-input dict, which does a direct dict lookup per key and would
+    raise a KeyError on a roth_c or species key, which have a different dict
+    shape.
 
-    Note: RothC and emission-factor routing not included (yet) — emission factors 
+    Note: emission-factor routing not included (yet) — emission factors
     have a separate, non-distribution_dict path (emission_distribution_dict /
-    sample_emission_factors).
+    sample_emission_factors). Nothing here checks that a roth_c_* key is only
+    supplied when the RothC soil model is actually selected — that check
+    belongs at the caller, which knows soil_model_type.
     """
-    tree_species, crop_species, pool_species, input_dict = {}, {}, {}, {}
+    roth_c, tree_species, crop_species, pool_species, input_dict = {}, {}, {}, {}, {}
     for key, spec in (dist or {}).items():
-        if TREE_SPECIES_DIST_KEY_PATTERN.match(key):
+        if key in ROTH_C_DIST_KEYS:
+            roth_c[key] = spec
+        elif TREE_SPECIES_DIST_KEY_PATTERN.match(key):
             tree_species[key] = spec
         elif CROP_SPECIES_DIST_KEY_PATTERN.match(key):
             crop_species[key] = spec
@@ -68,7 +77,7 @@ def _partition_distributions(
             pool_species[key] = spec
         else:
             input_dict[key] = spec
-    return tree_species, crop_species, pool_species, input_dict
+    return roth_c, tree_species, crop_species, pool_species, input_dict
 
 
 def _run_single_sample(arguments: SampleArgs):
@@ -87,6 +96,7 @@ def _run_single_sample(arguments: SampleArgs):
         tree_species_data=arguments.tree_species_data,
         crop_species_data=arguments.crop_species_data,
         pool_species_data=arguments.pool_species_data,
+        soil_model_params=arguments.soil_model_params,
     )
 
 
@@ -116,9 +126,20 @@ def run_monte_carlo(
 
     rng = np.random.default_rng(seed)
 
-    tree_species_dists, crop_species_dists, pool_species_dists, input_dict_dists = (
+    roth_c_dists, tree_species_dists, crop_species_dists, pool_species_dists, input_dict_dists = (
         _partition_distributions(distribution_dict)
     )
+
+    if not roth_c_dists:
+        soil_model_samples = [None] * n_samples
+    else:
+        soil_model_samples = sampler.sample_soil_model_params(
+            base=RothCParams(),
+            distributions=roth_c_dists,
+            key_prefix="roth_c",
+            n_samples=n_samples,
+            rng=rng,
+        )
 
     soil_samples = sampler.sample_soil_params(
         soil=soil_params,
@@ -193,6 +214,7 @@ def run_monte_carlo(
             emission_factor_samples_batch = emission_factor_samples[start:stop]
             soil_samples_batch = soil_samples[start:stop]
             climate_samples_batch = climate_samples[start:stop]
+            soil_model_samples_batch = soil_model_samples[start:stop]
             tree_species_samples_batch = tree_species_samples[start:stop]
             crop_species_samples_batch = crop_species_samples[start:stop]
             pool_species_samples_batch = pool_species_samples[start:stop]
@@ -207,6 +229,7 @@ def run_monte_carlo(
                     plot_index=plot_index,
                     soil_params=soil_samples_batch[i],
                     climate=climate_samples_batch[i],
+                    soil_model_params=soil_model_samples_batch[i],
                     allometry=allometry,
                     gwp=gwp,
                     tree_species_data=tree_species_samples_batch[i],

--- a/shamba/model/monte_carlo/runner.py
+++ b/shamba/model/monte_carlo/runner.py
@@ -11,6 +11,9 @@ from model.emit import EmissionFactors
 from model.monte_carlo.model_parameter_distributions import MODEL_PARAMETER_DISTRIBUTIONS
 from model.monte_carlo.distribution_handler import DistributionSpec
 from model.climate import ClimateData
+from model.tree_params import TREE_SPECIES_PARAM_FIELDS, TREE_SPECIES_DIST_KEY_PATTERN
+from model.crop_params import CROP_SPECIES_PARAM_FIELDS, CROP_SPECIES_DIST_KEY_PATTERN
+from model.tree_model import BIOMASS_POOL_PARAM_FIELDS, BIOMASS_POOL_DIST_KEY_PATTERN
 
 class MCSummaries(NamedTuple):
     base: Dict[str, np.ndarray]
@@ -33,6 +36,39 @@ class SampleArgs(NamedTuple):
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY
     gwp: dict = CONSTANTS.GWP_list[CONSTANTS.DEFAULT_GWP]
 
+
+
+def _partition_distributions(
+    dist: Optional[Dict[str, DistributionSpec]],
+) -> Tuple[
+    Dict[str, DistributionSpec],
+    Dict[str, DistributionSpec],
+    Dict[str, DistributionSpec],
+    Dict[str, DistributionSpec],
+]:
+    """Split a user distributions dict by key pattern.
+
+    Species-lookup entries (tree_*_sp{N}, crop_*_sp{N}, pool_*_sp{N}) route to
+    sample_species_params() for their own species-lookup table; everything else
+    falls through to draw_samples() against the flat intervention-input dict,
+    which does a direct dict lookup per key and would raise a KeyError on a
+    species key, which has a different dict shape.
+
+    Note: RothC and emission-factor routing not included (yet) — emission factors 
+    have a separate, non-distribution_dict path (emission_distribution_dict /
+    sample_emission_factors).
+    """
+    tree_species, crop_species, pool_species, input_dict = {}, {}, {}, {}
+    for key, spec in (dist or {}).items():
+        if TREE_SPECIES_DIST_KEY_PATTERN.match(key):
+            tree_species[key] = spec
+        elif CROP_SPECIES_DIST_KEY_PATTERN.match(key):
+            crop_species[key] = spec
+        elif BIOMASS_POOL_DIST_KEY_PATTERN.match(key):
+            pool_species[key] = spec
+        else:
+            input_dict[key] = spec
+    return tree_species, crop_species, pool_species, input_dict
 
 
 def _run_single_sample(arguments: SampleArgs):
@@ -80,6 +116,10 @@ def run_monte_carlo(
 
     rng = np.random.default_rng(seed)
 
+    tree_species_dists, crop_species_dists, pool_species_dists, input_dict_dists = (
+        _partition_distributions(distribution_dict)
+    )
+
     soil_samples = sampler.sample_soil_params(
         soil=soil_params,
         n_samples=n_samples,
@@ -88,6 +128,31 @@ def run_monte_carlo(
 
     climate_samples = sampler.sample_climate_params(
         climate=climate,
+        n_samples=n_samples,
+        rng=rng,
+    )
+
+    tree_species_samples = sampler.sample_species_params(
+        base_params=tree_species_data,
+        distributions=tree_species_dists,
+        param_fields=TREE_SPECIES_PARAM_FIELDS,
+        key_prefix="tree",
+        n_samples=n_samples,
+        rng=rng,
+    )
+    crop_species_samples = sampler.sample_species_params(
+        base_params=crop_species_data,
+        distributions=crop_species_dists,
+        param_fields=CROP_SPECIES_PARAM_FIELDS,
+        key_prefix="crop",
+        n_samples=n_samples,
+        rng=rng,
+    )
+    pool_species_samples = sampler.sample_species_params(
+        base_params=pool_species_data,
+        distributions=pool_species_dists,
+        param_fields=BIOMASS_POOL_PARAM_FIELDS,
+        key_prefix="pool",
         n_samples=n_samples,
         rng=rng,
     )
@@ -103,12 +168,12 @@ def run_monte_carlo(
         emission_factor_samples = [EmissionFactors() for _ in range(n_samples)]
 
 
-    if distribution_dict is None:
+    if not input_dict_dists:
         samples = [dict(base_input_dict) for _ in range(n_samples)]
     else:
         samples = sampler.draw_samples(
             base_input_dict=base_input_dict,
-            distributions=distribution_dict,
+            distributions=input_dict_dists,
             n_samples=n_samples,
             rng=rng,
         )
@@ -128,6 +193,9 @@ def run_monte_carlo(
             emission_factor_samples_batch = emission_factor_samples[start:stop]
             soil_samples_batch = soil_samples[start:stop]
             climate_samples_batch = climate_samples[start:stop]
+            tree_species_samples_batch = tree_species_samples[start:stop]
+            crop_species_samples_batch = crop_species_samples[start:stop]
+            pool_species_samples_batch = pool_species_samples[start:stop]
             results.extend(list(executor.map(_run_single_sample, [
                 SampleArgs(
                     perturbed_intervention_input=samples_batch[i],
@@ -141,9 +209,9 @@ def run_monte_carlo(
                     climate=climate_samples_batch[i],
                     allometry=allometry,
                     gwp=gwp,
-                    tree_species_data=tree_species_data,
-                    crop_species_data=crop_species_data,
-                    pool_species_data=pool_species_data,
+                    tree_species_data=tree_species_samples_batch[i],
+                    crop_species_data=crop_species_samples_batch[i],
+                    pool_species_data=pool_species_samples_batch[i],
                 )
                 for i in range(len(samples_batch))
             ])))

--- a/shamba/model/monte_carlo/runner.py
+++ b/shamba/model/monte_carlo/runner.py
@@ -127,6 +127,7 @@ def run_monte_carlo(
             samples_batch = samples[start:stop]
             emission_factor_samples_batch = emission_factor_samples[start:stop]
             soil_samples_batch = soil_samples[start:stop]
+            climate_samples_batch = climate_samples[start:stop]
             results.extend(list(executor.map(_run_single_sample, [
                 SampleArgs(
                     perturbed_intervention_input=samples_batch[i],
@@ -137,7 +138,7 @@ def run_monte_carlo(
                     n_base_cohorts=n_base_cohorts,
                     plot_index=plot_index,
                     soil_params=soil_samples_batch[i],
-                    climate=climate_samples[i],
+                    climate=climate_samples_batch[i],
                     allometry=allometry,
                     gwp=gwp,
                     tree_species_data=tree_species_data,

--- a/shamba/model/monte_carlo/runner.py
+++ b/shamba/model/monte_carlo/runner.py
@@ -62,9 +62,10 @@ def _partition_distributions(
 
     Note: emission-factor routing not included (yet) — emission factors
     have a separate, non-distribution_dict path (emission_distribution_dict /
-    sample_emission_factors). Nothing here checks that a roth_c_* key is only
-    supplied when the RothC soil model is actually selected — that check
-    belongs at the caller, which knows soil_model_type.
+    sample_emission_factors).
+    Whilst upstream parts of the code are generic in handling SoilModelParams, 
+    the Monte Carlo runner currently does not include soil_model_type checks and
+    is currently hard-coded to RothCParams, so this function only handles RothC keys.
     """
     roth_c, tree_species, crop_species, pool_species, input_dict = {}, {}, {}, {}, {}
     for key, spec in (dist or {}).items():

--- a/shamba/model/monte_carlo/runner.py
+++ b/shamba/model/monte_carlo/runner.py
@@ -15,6 +15,7 @@ from model.tree_params import TREE_SPECIES_PARAM_FIELDS, TREE_SPECIES_DIST_KEY_P
 from model.crop_params import CROP_SPECIES_PARAM_FIELDS, CROP_SPECIES_DIST_KEY_PATTERN
 from model.tree_model import BIOMASS_POOL_PARAM_FIELDS, BIOMASS_POOL_DIST_KEY_PATTERN
 from model.soil_models.soil_model_params import RothCParams, SoilModelParams, ROTH_C_DIST_KEYS
+from model.soil_models.soil_model_types import SoilModelType
 
 class MCSummaries(NamedTuple):
     base: Dict[str, np.ndarray]
@@ -326,6 +327,8 @@ def write_mc_metadata(
     output_path: str,
     n_samples: int,
     seed: Optional[int],
+    soil_model_type: SoilModelType,
+    repo_state: str,
     soil_params: SoilParams.SoilParamsData,
     climate,
     distribution_dict: Optional[Dict[str, DistributionSpec]],
@@ -336,6 +339,8 @@ def write_mc_metadata(
     lines.append("SHAMBA Monte Carlo run metadata")
     lines.append("=" * 40)
     lines.append(f"Run timestamp : {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}")
+    lines.append(f"Soil model    : {soil_model_type.value}")
+    lines.append(f"Repo commit   : {repo_state}")
     lines.append(f"Samples       : {n_samples}")
     if seed is None:
         lines.append("Seed          : not set — run is not reproducible")

--- a/shamba/model/monte_carlo/runner.py
+++ b/shamba/model/monte_carlo/runner.py
@@ -26,6 +26,9 @@ class SampleArgs(NamedTuple):
     plot_index: int
     soil_params: SoilParams.SoilParamsData
     climate: ClimateData
+    tree_species_data: Dict[int, Dict]
+    crop_species_data: Dict[int, Dict]
+    pool_species_data: Dict[int, Dict]
     emission_factors: EmissionFactors = EmissionFactors()
     allometry: List[str] = CONSTANTS.DEFAULT_ALLOMORPHY
     gwp: dict = CONSTANTS.GWP_list[CONSTANTS.DEFAULT_GWP]
@@ -44,7 +47,10 @@ def _run_single_sample(arguments: SampleArgs):
         plot_index=arguments.plot_index,
         allometry=arguments.allometry,
         gwp=arguments.gwp,
-        emission_factors=arguments.emission_factors
+        emission_factors=arguments.emission_factors,
+        tree_species_data=arguments.tree_species_data,
+        crop_species_data=arguments.crop_species_data,
+        pool_species_data=arguments.pool_species_data,
     )
 
 
@@ -58,6 +64,9 @@ def run_monte_carlo(
     n_proj_cohorts: int,
     n_base_cohorts: int,
     plot_index: int,
+    tree_species_data: Dict[int, Dict],
+    crop_species_data: Dict[int, Dict],
+    pool_species_data: Dict[int, Dict],
     sample_emission_factors: bool = False,
     distribution_dict: Optional[Dict] = None,
     model_params: Optional[EmissionFactors] = EmissionFactors(),
@@ -131,6 +140,9 @@ def run_monte_carlo(
                     climate=climate_samples[i],
                     allometry=allometry,
                     gwp=gwp,
+                    tree_species_data=tree_species_data,
+                    crop_species_data=crop_species_data,
+                    pool_species_data=pool_species_data,
                 )
                 for i in range(len(samples_batch))
             ])))

--- a/shamba/model/monte_carlo/sampler.py
+++ b/shamba/model/monte_carlo/sampler.py
@@ -17,6 +17,7 @@ from model.monte_carlo.model_parameter_distributions import MODEL_PARAMETER_DIST
 from model.common.data_handler import get_header_type
 import model.soil_params as SoilParams
 from model.climate import ClimateData
+from model.soil_models.soil_model_params import SoilModelParams
 
 # Climate parameter keys — perturbation is applied as a multiplicative scalar
 # to preserve the seasonal structure of the monthly vector.
@@ -414,6 +415,50 @@ def sample_climate_params(
         ))
 
     return results
+
+def sample_soil_model_params(
+    base: SoilModelParams,
+    distributions: Dict[str, DistributionSpec],
+    key_prefix: str,
+    n_samples: int,
+    rng: np.random.Generator,
+) -> List[SoilModelParams]:
+    """Draw N soil-model parameter objects from a base object and matching distributions.
+
+    Shared engine for every soil model's parameter NamedTuple (currently
+    RothCParams; ExampleSoilModelParams has no fields, so it always returns
+    copies of base unchanged). Each field is perturbed only if `distributions`
+    has a matching `{key_prefix}_{field}` entry; fields without one keep their
+    base value in every sample. If `distributions` is empty, returns
+    n_samples copies of `base`.
+
+    Args:
+        base: soil-model parameter object (e.g. RothCParams()) holding the
+            central (default or user-supplied) values.
+        distributions: mapping of "{key_prefix}_{field}" to DistributionSpec.
+        key_prefix: distribution-key prefix for this soil model (e.g. "roth_c").
+        n_samples: number of samples to draw.
+        rng: numpy random Generator.
+
+    Returns:
+        list of n_samples soil-model parameter objects, same type as `base`,
+        with any distributed fields perturbed.
+    """
+    base_dict = base._asdict()
+    field_specs = {
+        field: distributions[key]
+        for field in base_dict
+        if (key := f"{key_prefix}_{field}") in distributions
+    }
+
+    samples = []
+    for _ in range(n_samples):
+        sample = dict(base_dict)
+        for field, spec in field_specs.items():
+            sample[field] = _draw_one(spec, float(base_dict[field]), rng)
+        samples.append(type(base)(**sample))
+    return samples
+
 
 def sample_species_params(
     base_params: Dict[int, Dict],

--- a/shamba/model/monte_carlo/sampler.py
+++ b/shamba/model/monte_carlo/sampler.py
@@ -5,7 +5,7 @@ uncertainty stored in SoilParamsData and ClimateData (Issues P1/P2).
 """
 
 import warnings
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
 
 import numpy as np
 import scipy.stats
@@ -414,6 +414,57 @@ def sample_climate_params(
         ))
 
     return results
+
+def sample_species_params(
+    base_params: Dict[int, Dict],
+    distributions: Dict[str, DistributionSpec],
+    param_fields: Sequence[str],
+    key_prefix: str,
+    n_samples: int,
+    rng: np.random.Generator,
+) -> List[Dict[int, Dict]]:
+    """Draw N perturbed copies of a species-lookup dict.
+
+    Shared engine for every species catalog (tree, crop, biomass pool) — they all
+    share the same `Dict[int, Dict]` shape, keyed by species code (Sc), differing
+    only in which fields are eligible for sampling and what prefix disambiguates
+    their distribution keys. See TREE_SPECIES_PARAM_FIELDS (tree_params.py),
+    CROP_SPECIES_PARAM_FIELDS (crop_params.py), and BIOMASS_POOL_PARAM_FIELDS
+    (tree_model.py) for the field lists, and their matching DIST_KEY_PATTERNs for
+    the key prefixes ("tree_", "crop_", "pool_").
+
+    `base_params` is keyed by species code (Sc), as returned by the catalog's own
+    load_*_species_data(). For each species, a field is perturbed only if
+    `distributions` has a matching `{key_prefix}_{field}_sp{Sc}` entry;
+    species/fields without one keep their CSV central value in every sample. The
+    key prefix disambiguates fields (e.g. root_to_shoot) shared across catalogs
+    with independently-numbered species codes.
+
+    Returns:
+        list of n_samples dicts, each a full copy of `base_params` with any
+        distributed fields perturbed.
+    """
+    # Resolve, once, which (species, field) pairs actually have a distribution.
+    species_param_specs: Dict[int, Dict[str, DistributionSpec]] = {
+        sc: {
+            param: distributions[key]
+            for param in param_fields
+            if (key := f"{key_prefix}_{param}_sp{sc}") in distributions
+        }
+        for sc in base_params
+    }
+
+    samples = []
+    for _ in range(n_samples):
+        sample = {sc: dict(species) for sc, species in base_params.items()}
+        for sc, param_specs in species_param_specs.items():
+            for param, spec in param_specs.items():
+                arr = np.asarray(base_params[sc][param], dtype=float)
+                perturbed = np.array([_draw_one(spec, float(elem), rng) for elem in arr.ravel()])
+                sample[sc][param] = perturbed.reshape(arr.shape)
+        samples.append(sample)
+
+    return samples
 
 def sample_model_params(
     n_samples: int,

--- a/shamba/model/monte_carlo/sampler.py
+++ b/shamba/model/monte_carlo/sampler.py
@@ -425,7 +425,7 @@ def sample_species_params(
 ) -> List[Dict[int, Dict]]:
     """Draw N perturbed copies of a species-lookup dict.
 
-    Shared engine for every species catalog (tree, crop, biomass pool) — they all
+    Shared engine for every species-lookup table (tree, crop, biomass pool) — they all
     share the same `Dict[int, Dict]` shape, keyed by species code (Sc), differing
     only in which fields are eligible for sampling and what prefix disambiguates
     their distribution keys. See TREE_SPECIES_PARAM_FIELDS (tree_params.py),
@@ -433,12 +433,12 @@ def sample_species_params(
     (tree_model.py) for the field lists, and their matching DIST_KEY_PATTERNs for
     the key prefixes ("tree_", "crop_", "pool_").
 
-    `base_params` is keyed by species code (Sc), as returned by the catalog's own
-    load_*_species_data(). For each species, a field is perturbed only if
-    `distributions` has a matching `{key_prefix}_{field}_sp{Sc}` entry;
+    `base_params` is keyed by species code (Sc), as returned by the species-lookup
+    table's own load_*_species_data(). For each species, a field is perturbed
+    only if `distributions` has a matching `{key_prefix}_{field}_sp{Sc}` entry;
     species/fields without one keep their CSV central value in every sample. The
-    key prefix disambiguates fields (e.g. root_to_shoot) shared across catalogs
-    with independently-numbered species codes.
+    key prefix disambiguates fields (e.g. root_to_shoot) shared across
+    species-lookup tables with independently-numbered species codes.
 
     Returns:
         list of n_samples dicts, each a full copy of `base_params` with any

--- a/shamba/model/monte_carlo/sampler.py
+++ b/shamba/model/monte_carlo/sampler.py
@@ -463,7 +463,7 @@ def sample_soil_model_params(
 def sample_species_params(
     base_params: Dict[int, Dict],
     distributions: Dict[str, DistributionSpec],
-    param_fields: Sequence[str],
+    param_fields: Sequence[str], # guarantees order, len(), and indexing/slicing, but not mutation
     key_prefix: str,
     n_samples: int,
     rng: np.random.Generator,
@@ -505,6 +505,11 @@ def sample_species_params(
         for sc, param_specs in species_param_specs.items():
             for param, spec in param_specs.items():
                 arr = np.asarray(base_params[sc][param], dtype=float)
+                # For biomass-pool fields, arr holds one value per pool (leaf/branch/
+                # stem/croot/froot, tree_model._BIOMASS_POOLS order). One distribution
+                # key (e.g. pool_alloc_sp2) perturbs all 5 independently from the same
+                # distribution spec — each pool draws its own random value around its
+                # own base, not a shared draw.
                 perturbed = np.array([_draw_one(spec, float(elem), rng) for elem in arr.ravel()])
                 sample[sc][param] = perturbed.reshape(arr.shape)
         samples.append(sample)

--- a/shamba/model/soil_models/example_soil_model/forward_example.py
+++ b/shamba/model/soil_models/example_soil_model/forward_example.py
@@ -1,4 +1,5 @@
 from ..soil_model_types import ForwardSoilModelData, ForwardSoilModelBaseSchema
+from ..soil_model_params import ExampleSoilModelParams
 
 
 def create(
@@ -12,6 +13,7 @@ def create(
     litter=[],
     fire=[],
     solve_to_value=False,
+    soil_model_params: ExampleSoilModelParams = ExampleSoilModelParams(),
 ) -> ForwardSoilModelData:
     schema = ForwardSoilModelBaseSchema()
     params = {}

--- a/shamba/model/soil_models/example_soil_model/inverse_example.py
+++ b/shamba/model/soil_models/example_soil_model/inverse_example.py
@@ -1,9 +1,15 @@
 import numpy as np
 
 from ..soil_model_types import InverseSoilModelData, InverseSoilModelBaseSchema
+from ..soil_model_params import ExampleSoilModelParams
 
 
-def create(soil, climate, cover=np.ones(12)) -> InverseSoilModelData:
+def create(
+    soil,
+    climate,
+    cover=np.ones(12),
+    soil_model_params: ExampleSoilModelParams = ExampleSoilModelParams(),
+) -> InverseSoilModelData:
     schema = InverseSoilModelBaseSchema()
     params = {}
     # This will fail because params is empty

--- a/shamba/model/soil_models/roth_c/forward_roth_c.py
+++ b/shamba/model/soil_models/roth_c/forward_roth_c.py
@@ -13,7 +13,7 @@ from ...common import csv_handler
 from .roth_c import SoilModelBaseSchema
 from .roth_c import create as create_roth_c
 from .roth_c import dC_dt
-from .roth_c_params import RothCParams
+from ..soil_model_params import RothCParams
 from ..soil_model_types import ForwardSoilModelData, ForwardSoilModelBaseSchema
 
 
@@ -28,7 +28,7 @@ def create(
     litter=[],
     fire=[],
     solve_to_value=False,
-    roth_c_params: RothCParams = RothCParams(),
+    soil_model_params: RothCParams = RothCParams(),
 ) -> ForwardSoilModelData:
     """Creates ForwardSoilModelData.
 
@@ -41,14 +41,15 @@ def create(
         tree: list of tree objects which provide carbon to soil
         litter: list of litter objects which provide carbon to soil
         solve_to_value: whether to solve to value (to Cy0) or by time
-        roth_c_params: rate-modifier and partitioning constants (defaults are RothC standard values)
+        soil_model_params: RothC rate-modifier and partitioning constants (defaults
+            are RothC standard values). Generic naming because other soil models could be used.
 
     """
-    roth_c = create_roth_c(soil, climate, cover, no_of_years, roth_c_params=roth_c_params)
+    roth_c = create_roth_c(soil, climate, cover, no_of_years, roth_c_params=soil_model_params)
 
     SOC, inputs, Cy0Year = solver(
         roth_c, Ci, no_of_years, crop, tree, litter, fire, solve_to_value,
-        roth_c_params=roth_c_params,
+        roth_c_params=soil_model_params,
     )
 
     params = {

--- a/shamba/model/soil_models/roth_c/forward_roth_c.py
+++ b/shamba/model/soil_models/roth_c/forward_roth_c.py
@@ -13,6 +13,7 @@ from ...common import csv_handler
 from .roth_c import SoilModelBaseSchema
 from .roth_c import create as create_roth_c
 from .roth_c import dC_dt
+from .roth_c_params import RothCParams
 from ..soil_model_types import ForwardSoilModelData, ForwardSoilModelBaseSchema
 
 
@@ -27,6 +28,7 @@ def create(
     litter=[],
     fire=[],
     solve_to_value=False,
+    roth_c_params: RothCParams = RothCParams(),
 ) -> ForwardSoilModelData:
     """Creates ForwardSoilModelData.
 
@@ -39,12 +41,14 @@ def create(
         tree: list of tree objects which provide carbon to soil
         litter: list of litter objects which provide carbon to soil
         solve_to_value: whether to solve to value (to Cy0) or by time
+        roth_c_params: rate-modifier and partitioning constants (defaults are RothC standard values)
 
     """
-    roth_c = create_roth_c(soil, climate, cover, no_of_years)
+    roth_c = create_roth_c(soil, climate, cover, no_of_years, roth_c_params=roth_c_params)
 
     SOC, inputs, Cy0Year = solver(
-        roth_c, Ci, no_of_years, crop, tree, litter, fire, solve_to_value
+        roth_c, Ci, no_of_years, crop, tree, litter, fire, solve_to_value,
+        roth_c_params=roth_c_params,
     )
 
     params = {
@@ -67,7 +71,8 @@ def create(
 
 
 def solver(
-    roth_c, Ci, no_of_years, crop=[], tree=[], litter=[], fire=[], solve_to_value=False
+    roth_c, Ci, no_of_years, crop=[], tree=[], litter=[], fire=[], solve_to_value=False,
+    roth_c_params: RothCParams = RothCParams(),
 ):
     """Run RothC in 'forward' mode;
     solve dC_dt over a given time period
@@ -97,7 +102,7 @@ def solver(
     inputs = np.column_stack((soilIn_crop, soilIn_tree))
 
     # Calculate yearly values of x based dpm:rpm ratio for each year
-    x = get_partitions(roth_c, inputs, no_of_years)
+    x = get_partitions(roth_c, inputs, no_of_years, roth_c_params=roth_c_params)
     t = np.arange(0, 1, 0.001)
     C = np.zeros((no_of_years + 1, 4))
     C[0] = Ci
@@ -151,11 +156,14 @@ def solver(
     return C, inputs, year_target_reached
 
 
-def get_partitions(roth_c, inputs, no_of_years):
+def get_partitions(
+    roth_c, inputs, no_of_years, roth_c_params: RothCParams = RothCParams()
+):
     """Calculate partitioning coefficients.
 
     Args:
         input: 2d array with crop_in,tree_in inputs as the columns
+        roth_c_params: DPM/RPM partitioning constants (defaults are RothC standard values)
     Returns:
         x: partitioning coefficient (as a vector for each year)
 
@@ -184,7 +192,10 @@ def get_partitions(roth_c, inputs, no_of_years):
         i += 1
 
     # Weighted mean of dpm
-    p1 = np.array(0.59 * norm_input[:, 0] + 0.2 * norm_input[:, 1])
+    p1 = np.array(
+        roth_c_params.dpm_frac_crop * norm_input[:, 0]
+        + roth_c_params.dpm_frac_tree * norm_input[:, 1]
+    )
 
     # Construct x
     # make arrays (p1 already array)

--- a/shamba/model/soil_models/roth_c/inverse_roth_c.py
+++ b/shamba/model/soil_models/roth_c/inverse_roth_c.py
@@ -6,6 +6,7 @@ from scipy import optimize
 
 from ...common import csv_handler
 from .roth_c import create as create_roth_c, dC_dt
+from .roth_c_params import RothCParams
 from ..soil_model_types import (
     InverseSoilModelData,
     BaseSoilModelData,
@@ -13,18 +14,21 @@ from ..soil_model_types import (
 )
 
 
-def create(soil, climate, cover=np.ones(12)) -> InverseSoilModelData:
+def create(
+    soil, climate, cover=np.ones(12), roth_c_params: RothCParams = RothCParams()
+) -> InverseSoilModelData:
     """Creates inverse rothc object.
 
     Args:
         soil: soil object with soil parameters
         climate: climate object with climate parameters
         cover: monthly soil cover vector
+        roth_c_params: rate-modifier and partitioning constants (defaults are RothC standard values)
 
     """
-    roth_c = create_roth_c(soil, climate, cover, no_of_years = 1)
+    roth_c = create_roth_c(soil, climate, cover, no_of_years=1, roth_c_params=roth_c_params)
 
-    eq_C, input_C, x = solver(roth_c)
+    eq_C, input_C, x = solver(roth_c, roth_c_params=roth_c_params)
 
     params = {
         "soil_params": vars(roth_c.soil),
@@ -45,9 +49,12 @@ def create(soil, climate, cover=np.ones(12)) -> InverseSoilModelData:
     return schema.load(params)  # type: ignore
 
 
-def solver(roth_c):
+def solver(roth_c, roth_c_params: RothCParams = RothCParams()):
     """Run RothC in 'inverse' mode to find inputs
     giving equilibrium and Carbon pool values at equilibrium.
+
+    Args:
+        roth_c_params: DPM/RPM partitioning constants (defaults are RothC standard values)
 
     Returns:
         eq_C: equilibrium distribution of carbon
@@ -57,7 +64,7 @@ def solver(roth_c):
     """
 
     # Partioning coefficients
-    x = get_partitions(roth_c)
+    x = get_partitions(roth_c, roth_c_params=roth_c_params)
     t = 0  # just needed to define for dC_dt function
     C0 = np.array([0.1, 10, 0, 0])  # initial ballpark guess
 
@@ -83,8 +90,11 @@ def solver(roth_c):
     return eq_C, eq_input, x
 
 
-def get_partitions(roth_c):
+def get_partitions(roth_c, roth_c_params: RothCParams = RothCParams()):
     """Calculate partitioning coefficients.
+
+    Args:
+        roth_c_params: DPM/RPM partitioning constants (defaults are RothC standard values)
 
     Returns:
         x: partitioning coefficient for the 4 pools
@@ -99,10 +109,10 @@ def get_partitions(roth_c):
     p3 = 0.46  # BIO proportion of BIO+HUM
 
     # p_1 is dpm fraction of input:
-    #   deciduous tropical woodland: dpm=0.2, rpm=0.8
-    #   crops: dpm=0.59, rpm=0.41
-    # no crops at equil so p1 always 0.2
-    p1 = 0.2
+    #   deciduous tropical woodland: dpm=dpm_frac_tree, rpm=1-dpm_frac_tree
+    #   crops: dpm=dpm_frac_crop, rpm=1-dpm_frac_crop
+    # no crops at equilibrium, so p1 is always dpm_frac_tree
+    p1 = roth_c_params.dpm_frac_tree
 
     # DPM fraction, RPM fraction, BIO fraction, HUM fraction
     return np.array([p1, 1 - p1, p3 * (1 - p2), (1 - p2) * (1 - p3)])

--- a/shamba/model/soil_models/roth_c/inverse_roth_c.py
+++ b/shamba/model/soil_models/roth_c/inverse_roth_c.py
@@ -6,7 +6,7 @@ from scipy import optimize
 
 from ...common import csv_handler
 from .roth_c import create as create_roth_c, dC_dt
-from .roth_c_params import RothCParams
+from ..soil_model_params import RothCParams
 from ..soil_model_types import (
     InverseSoilModelData,
     BaseSoilModelData,
@@ -15,7 +15,7 @@ from ..soil_model_types import (
 
 
 def create(
-    soil, climate, cover=np.ones(12), roth_c_params: RothCParams = RothCParams()
+    soil, climate, cover=np.ones(12), soil_model_params: RothCParams = RothCParams()
 ) -> InverseSoilModelData:
     """Creates inverse rothc object.
 
@@ -23,12 +23,14 @@ def create(
         soil: soil object with soil parameters
         climate: climate object with climate parameters
         cover: monthly soil cover vector
-        roth_c_params: rate-modifier and partitioning constants (defaults are RothC standard values)
+        soil_model_params: RothC rate-modifier and partitioning constants (defaults
+            are RothC standard values). Generic naming because other soil models could be used.
+
 
     """
-    roth_c = create_roth_c(soil, climate, cover, no_of_years=1, roth_c_params=roth_c_params)
+    roth_c = create_roth_c(soil, climate, cover, no_of_years=1, roth_c_params=soil_model_params)
 
-    eq_C, input_C, x = solver(roth_c, roth_c_params=roth_c_params)
+    eq_C, input_C, x = solver(roth_c, roth_c_params=soil_model_params)
 
     params = {
         "soil_params": vars(roth_c.soil),

--- a/shamba/model/soil_models/roth_c/roth_c.py
+++ b/shamba/model/soil_models/roth_c/roth_c.py
@@ -7,19 +7,22 @@ from marshmallow import Schema, fields
 from ...climate import ClimateDataSchema
 from ...soil_params import SoilParamsSchema
 from ..soil_model_types import BaseSoilModelData, SoilModelBaseSchema
+from .roth_c_params import RothCParams
 
 
 # Class variables (defaults)
 K_BASE = np.array([10.0, 0.3, 0.66, 0.02])
 
 
-def create(soil, climate, cover, no_of_years):
+def create(soil, climate, cover, no_of_years, roth_c_params: RothCParams = RothCParams()):
     """Creates rothc object.
 
     Args:
         soil: SoilParams object with soil parameters
         climate: Climate object with climate parameters
         cover: monthly cover vector (1=covered, 0=uncovered)
+        roth_c_params: rate-modifier and partitioning constants (defaults preserve
+            prior hardcoded behaviour)
 
     """
 
@@ -27,7 +30,10 @@ def create(soil, climate, cover, no_of_years):
         "soil_params": vars(soil),
         "climate": vars(climate),
         "cover": cover,
-        "k": get_rmf(climate=climate, cover=cover, soil=soil, no_of_years=no_of_years)[..., np.newaxis] * K_BASE,
+        "k": get_rmf(
+            climate=climate, cover=cover, soil=soil, no_of_years=no_of_years,
+            roth_c_params=roth_c_params,
+        )[..., np.newaxis] * K_BASE,
     }
 
     schema = SoilModelBaseSchema()
@@ -41,11 +47,14 @@ def create(soil, climate, cover, no_of_years):
 
 
 # Rate modifying-factor function - needed in forward and inverse
-def get_rmf(climate, cover, soil, no_of_years):
+def get_rmf(climate, cover, soil, no_of_years, roth_c_params: RothCParams = RothCParams()):
     """Calculate the rate modifying factor for each year based on climate and soil cover.
 
     Supports both single-pattern climate/cover (12 values, repeated for all years)
     and multi-year climate/cover (12 * no_of_years values).
+
+    Args:
+        roth_c_params: rate-modifier constant values (defaults are RothC standard values)
 
     Returns:
         rmf: array of shape (no_of_years,) — yearly mean of the combined RMF
@@ -95,7 +104,12 @@ def get_rmf(climate, cover, soil, no_of_years):
             if accumulator_tsmd >= 0.444 * max_smd:
                 b[m] = 1
             elif accumulator_tsmd >= max_smd:
-                b[m] = 0.2 + 0.8 * (max_smd - accumulator_tsmd) / ((1 - 0.444) * max_smd)
+                b_min = 1 - roth_c_params.moisture_b_slope
+                b[m] = (
+                    b_min
+                    + roth_c_params.moisture_b_slope
+                    * (max_smd - accumulator_tsmd) / ((1 - 0.444) * max_smd)
+                )
             else:
                 log.error("DEFICIT = %5.2f" % accumulator_tsmd)
                 sys.exit(1)
@@ -107,11 +121,13 @@ def get_rmf(climate, cover, soil, no_of_years):
         # Temperature RMF (a)
         a = np.zeros(12)
         warm = temp > -5.0
-        a[warm] = 47.91 / (1.0 + np.exp(106.06 / (temp[warm] + 18.27)))
+        a[warm] = roth_c_params.temp_a1 / (
+            1.0 + np.exp(roth_c_params.temp_a2 / (temp[warm] + roth_c_params.temp_a3))
+        )
 
         # Soil cover RMF (c)
         c = np.ones(12)
-        c[cover_year == 1] = 0.6
+        c[cover_year == 1] = roth_c_params.cover_c
 
         rmf[y] = (a * b * c).mean()
 

--- a/shamba/model/soil_models/roth_c/roth_c.py
+++ b/shamba/model/soil_models/roth_c/roth_c.py
@@ -7,7 +7,7 @@ from marshmallow import Schema, fields
 from ...climate import ClimateDataSchema
 from ...soil_params import SoilParamsSchema
 from ..soil_model_types import BaseSoilModelData, SoilModelBaseSchema
-from .roth_c_params import RothCParams
+from ..soil_model_params import RothCParams
 
 
 # Class variables (defaults)

--- a/shamba/model/soil_models/roth_c/roth_c_params.py
+++ b/shamba/model/soil_models/roth_c/roth_c_params.py
@@ -1,0 +1,24 @@
+from typing import NamedTuple
+
+
+class RothCParams(NamedTuple):
+    """RothC rate-modifier and DPM/RPM partitioning constants.
+
+    Defaults match the values previously hardcoded in roth_c.py, forward_roth_c.py,
+    and inverse_roth_c.py — constructing RothCParams() with no arguments is
+    numerically equivalent to floating-point precision. The moisture RMF floor is
+    deliberately derived as (1 - moisture_b_slope) rather than stored as its own
+    field, since floor and slope describe the same linear interpolation and must
+    stay coupled under future perturbation (see get_rmf() in roth_c.py) — this
+    introduces a single last-bit (~1e-16 relative) rounding difference from the
+    prior hardcoded 0.2, well below the model's own numeric tolerances. Exists so
+    these constants can be overridden per call (e.g. by Monte Carlo sampling)
+    instead of being fixed at import time.
+    """
+    dpm_frac_crop: float = 0.59       # DPM fraction of crop carbon input
+    dpm_frac_tree: float = 0.20       # DPM fraction of tree carbon input
+    temp_a1: float = 47.91            # temperature modifier numerator
+    temp_a2: float = 106.06           # temperature modifier exponent numerator
+    temp_a3: float = 18.27            # temperature modifier offset
+    moisture_b_slope: float = 0.80    # moisture modifier slope (min = 1 - slope)
+    cover_c: float = 0.60             # rate modifier when soil is covered (bare = 1.0)

--- a/shamba/model/soil_models/soil_model_params.py
+++ b/shamba/model/soil_models/soil_model_params.py
@@ -1,4 +1,15 @@
-from typing import NamedTuple
+from typing import NamedTuple, Union
+
+class ExampleSoilModelParams(NamedTuple):
+    """Placeholder parameters for the example soil model.
+
+    The example soil model has no working implementation yet (forward_example.py/
+    inverse_example.py always fail schema validation). This class has no fields —
+    it exists so callers that don't know which soil model is active (e.g.
+    handle_intervention()) can pass a soil_model_params object uniformly, matching
+    RothCParams' role for the RothC model.
+    """
+    pass
 
 
 class RothCParams(NamedTuple):
@@ -22,3 +33,8 @@ class RothCParams(NamedTuple):
     temp_a3: float = 18.27            # temperature modifier offset
     moisture_b_slope: float = 0.80    # moisture modifier slope (min = 1 - slope)
     cover_c: float = 0.60             # rate modifier when soil is covered (bare = 1.0)
+
+
+# The concrete parameter type depends on which soil model create_forward_soil_model/
+# create_inverse_soil_model actually resolve to at runtime — one member per soil model.
+SoilModelParams = Union[RothCParams, ExampleSoilModelParams]

--- a/shamba/model/soil_models/soil_model_params.py
+++ b/shamba/model/soil_models/soil_model_params.py
@@ -38,3 +38,10 @@ class RothCParams(NamedTuple):
 # The concrete parameter type depends on which soil model create_forward_soil_model/
 # create_inverse_soil_model actually resolve to at runtime — one member per soil model.
 SoilModelParams = Union[RothCParams, ExampleSoilModelParams]
+
+# roth_c_{field} for each RothCParams field — e.g. "roth_c_temp_a1", "roth_c_cover_c".
+# Used by monte_carlo/runner.py's _partition_distributions() to route user-supplied
+# distribution keys to sample_soil_model_params(), matching the convention of
+# TREE_SPECIES_DIST_KEY_PATTERN/CROP_SPECIES_DIST_KEY_PATTERN/BIOMASS_POOL_DIST_KEY_PATTERN
+# living beside their own field lists.
+ROTH_C_DIST_KEYS = {f"roth_c_{field}" for field in RothCParams._fields}

--- a/shamba/model/tree_model.py
+++ b/shamba/model/tree_model.py
@@ -188,8 +188,9 @@ _BIOMASS_POOLS = ("leaf", "branch", "stem", "croot", "froot")
 # truth for both the key-matching pattern below and sampler.sample_species_params().
 BIOMASS_POOL_PARAM_FIELDS = ("turnover", "alloc", "thinning_fraction", "mortality_fraction")
 
-# Keys are prefixed with the catalog name ("pool_") rather than bare field names,
-# for consistency with the tree/crop catalogs' prefix convention (see tree_params.py).
+# Keys are prefixed with the species-lookup table name ("pool_") rather than bare
+# field names, for consistency with the tree/crop tables' prefix convention
+# (see tree_params.py).
 # Matches MC distribution keys for per-species biomass-pool parameter sampling, e.g.
 # "pool_turnover_sp2", "pool_alloc_sp1".
 BIOMASS_POOL_DIST_KEY_PATTERN = re.compile(
@@ -288,7 +289,7 @@ def load_biomass_pool_species_data(
 
 def get_species_pool_data(species: int, pool_species_data: Dict[int, Dict]) -> Dict:
     """Look up one species' biomass pool params, with a plain-language error
-    if the species is missing from the catalog.
+    if the species is missing from the species-lookup table.
 
     Args:
         species: species code (Sc column in tree_params.csv) to look up.
@@ -342,7 +343,8 @@ def from_defaults(
     # is the split of total AGB (Sec 4.3.2), and this must hold even when
     # stem has been perturbed by MC sampling. load_biomass_pool_species_data()
     # validates the raw CSV, but only re-deriving here (rather than trusting
-    # the catalog's branch value) keeps the identity true after perturbation.
+    # the species-lookup table's branch value) keeps the identity true after
+    # perturbation.
     alloc[1] = 1 - alloc[2]
     # Take into account croot alloc - rs * stem alloc
     alloc[3] = alloc[2] * tree_params.root_to_shoot

--- a/shamba/model/tree_model.py
+++ b/shamba/model/tree_model.py
@@ -3,6 +3,7 @@
 """Module containing Tree class."""
 
 import os
+import re
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -181,6 +182,18 @@ def create(
 
 
 _BIOMASS_POOLS = ("leaf", "branch", "stem", "croot", "froot")
+
+# Per-species fields eligible for MC distribution sampling — the single source of
+# truth for both the key-matching pattern below and sampler.sample_species_params().
+BIOMASS_POOL_PARAM_FIELDS = ("turnover", "alloc", "thinning_fraction", "mortality_fraction")
+
+# Keys are prefixed with the catalog name ("pool_") rather than bare field names,
+# for consistency with the tree/crop catalogs' prefix convention (see tree_params.py).
+# Matches MC distribution keys for per-species biomass-pool parameter sampling, e.g.
+# "pool_turnover_sp2", "pool_alloc_sp1".
+BIOMASS_POOL_DIST_KEY_PATTERN = re.compile(
+    rf"^pool_({'|'.join(BIOMASS_POOL_PARAM_FIELDS)})_sp(\d+)$"
+)
 
 
 def load_biomass_pool_species_data(

--- a/shamba/model/tree_model.py
+++ b/shamba/model/tree_model.py
@@ -4,6 +4,7 @@
 
 import os
 import re
+from typing import Dict
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -272,6 +273,28 @@ def load_biomass_pool_species_data(
     return species_data
 
 
+def get_species_pool_data(species: int, pool_species_data: Dict[int, Dict]) -> Dict:
+    """Look up one species' biomass pool params, with a plain-language error
+    if the species is missing from the catalog.
+
+    Args:
+        species: species code (Sc column in tree_params.csv) to look up.
+        pool_species_data: pre-loaded biomass pool data (as returned by
+            load_biomass_pool_species_data()), loaded once per run by the caller.
+
+    Returns:
+        Dict with turnover, alloc, thinning_fraction, and mortality_fraction
+        arrays (one value per pool, in leaf/branch/stem/croot/froot order).
+    """
+    if species not in pool_species_data:
+        raise KeyError(
+            f"No biomass pool parameters found for species '{species}' "
+            "in biomass_pool_params.csv. Add a 5-row block (leaf, branch, stem, "
+            "croot, froot) for this species, in the same order as tree_params.csv."
+        )
+    return pool_species_data[species]
+
+
 def from_defaults(
     tree_params,
     tree_growth,
@@ -292,14 +315,7 @@ def from_defaults(
             load_biomass_pool_species_data()), loaded once per run by the caller.
     """
 
-    pool_data = pool_species_data
-    if tree_params.species not in pool_data:
-        raise KeyError(
-            f"No biomass pool parameters found for species '{tree_params.species}' "
-            "in biomass_pool_params.csv. Add a 5-row block (leaf, branch, stem, "
-            "croot, froot) for this species, in the same order as tree_params.csv."
-        )
-    species_pool_data = pool_data[tree_params.species]
+    species_pool_data = get_species_pool_data(tree_params.species, pool_species_data)
     turnover = species_pool_data["turnover"]
     # pool_data may be a dict shared across every cohort of this species (see
     # pool_species_data above) rather than freshly read each call — copy

--- a/shamba/model/tree_model.py
+++ b/shamba/model/tree_model.py
@@ -264,23 +264,22 @@ def from_defaults(
     tree_growth,
     no_of_years,
     stand_density,
+    pool_species_data,
     year_planted=0,
     thinning=None,
     thinning_fraction=None,
     mortality=None,
     mortality_fraction=None,
-    pool_species_data=None,
 ):
     """Use defaults for pool params.
     Can override defaults for thinning_fraction and mortality_fraction by providing arguments.
 
     Args:
         pool_species_data: pre-loaded biomass pool data (as returned by
-            load_biomass_pool_species_data()), to avoid re-reading the csv
-            from disk once per cohort. If not given, loads it fresh.
+            load_biomass_pool_species_data()), loaded once per run by the caller.
     """
 
-    pool_data = pool_species_data if pool_species_data is not None else load_biomass_pool_species_data()
+    pool_data = pool_species_data
     if tree_params.species not in pool_data:
         raise KeyError(
             f"No biomass pool parameters found for species '{tree_params.species}' "
@@ -616,7 +615,7 @@ def create_tree_projects(
     no_of_years,
     cohort_count,
     type,
-    pool_species_data=None,
+    pool_species_data,
 ):
     return [
         from_defaults(

--- a/shamba/model/tree_model.py
+++ b/shamba/model/tree_model.py
@@ -272,10 +272,9 @@ def load_biomass_pool_species_data(
         branch_al, stem_al = ordered[1, 1], ordered[2, 1]
         if not np.isclose(branch_al + stem_al, 1.0, atol=1e-6):
             raise ValueError(
-                f"'{filename}': branch and stem 'AL' (allocation) values for species "
-                f"code {species} must sum to 1 — they represent a split of total "
-                f"above-ground biomass — but found branch={branch_al}, stem={stem_al} "
-                f"(sum={branch_al + stem_al})."
+                f"'{filename}': branch and stem 'AL' (allocation) values are a split of "
+                f"total aboveground biomass and must sum to 1."
+                f" For {species} found branch={branch_al}, stem={stem_al} (sum={branch_al + stem_al})."
             )
 
         species_data[species] = {
@@ -341,10 +340,10 @@ def from_defaults(
 
     # Branch alloc is derived from stem, not read independently — branch+stem
     # is the split of total AGB (Sec 4.3.2), and this must hold even when
-    # stem has been perturbed by MC sampling. load_biomass_pool_species_data()
-    # validates the raw CSV, but only re-deriving here (rather than trusting
-    # the species-lookup table's branch value) keeps the identity true after
-    # perturbation.
+    # stem has been perturbed by MC sampling. sample_species_params() has no
+    # knowledge of this identity — it draws branch and stem independently — so
+    # whatever branch value it sampled is discarded here and re-derived from
+    # stem's (possibly sampled) value instead.
     alloc[1] = 1 - alloc[2]
     # Take into account croot alloc - rs * stem alloc
     alloc[3] = alloc[2] * tree_params.root_to_shoot

--- a/shamba/model/tree_model.py
+++ b/shamba/model/tree_model.py
@@ -264,6 +264,19 @@ def load_biomass_pool_species_data(
                 f"{_BIOMASS_POOLS}."
             )
         ordered = np.array([pools[p] for p in _BIOMASS_POOLS])
+
+        # Branch and stem 'AL' are a split of total above-ground biomass
+        # (SHAMBA_ModelDescription_v1.2, Sec 4.3.2 / Table 3: alstem+albranch
+        # ratios always sum to 1 across every species in the reference data).
+        branch_al, stem_al = ordered[1, 1], ordered[2, 1]
+        if not np.isclose(branch_al + stem_al, 1.0, atol=1e-6):
+            raise ValueError(
+                f"'{filename}': branch and stem 'AL' (allocation) values for species "
+                f"code {species} must sum to 1 — they represent a split of total "
+                f"above-ground biomass — but found branch={branch_al}, stem={stem_al} "
+                f"(sum={branch_al + stem_al})."
+            )
+
         species_data[species] = {
             "turnover": ordered[:, 0],
             "alloc": ordered[:, 1],
@@ -325,6 +338,12 @@ def from_defaults(
     temp_thinning_fraction = species_pool_data["thinning_fraction"]
     temp_mortality_fraction = species_pool_data["mortality_fraction"]
 
+    # Branch alloc is derived from stem, not read independently — branch+stem
+    # is the split of total AGB (Sec 4.3.2), and this must hold even when
+    # stem has been perturbed by MC sampling. load_biomass_pool_species_data()
+    # validates the raw CSV, but only re-deriving here (rather than trusting
+    # the catalog's branch value) keeps the identity true after perturbation.
+    alloc[1] = 1 - alloc[2]
     # Take into account croot alloc - rs * stem alloc
     alloc[3] = alloc[2] * tree_params.root_to_shoot
 

--- a/shamba/model/tree_params.py
+++ b/shamba/model/tree_params.py
@@ -10,10 +10,11 @@ from model.common import csv_handler
 # truth for both the key-matching pattern below and sampler.sample_species_params().
 TREE_SPECIES_PARAM_FIELDS = ("wood_dens", "carbon", "root_to_shoot", "nitrogen")
 
-# Keys are prefixed with the catalog name ("tree_") rather than bare field names,
-# since some fields (e.g. root_to_shoot) also exist on other species catalogs
-# (crop_params.csv) with independently-numbered species codes — a bare key would
-# be ambiguous between "tree species 3" and "crop species 3".
+# Keys are prefixed with the species-lookup table name ("tree_") rather than bare
+# field names, since some fields (e.g. root_to_shoot) also exist in other
+# species-lookup tables (crop_params.csv) with independently-numbered species
+# codes — a bare key would be ambiguous between "tree species 3" and "crop
+# species 3".
 # Matches MC distribution keys for per-species tree parameter sampling, e.g.
 # "tree_wood_dens_sp2", "tree_carbon_sp1", "tree_nitrogen_sp3".
 TREE_SPECIES_DIST_KEY_PATTERN = re.compile(

--- a/shamba/model/tree_params.py
+++ b/shamba/model/tree_params.py
@@ -7,7 +7,7 @@ from marshmallow import Schema, fields, post_load
 from model.common import csv_handler
 
 # Per-species fields eligible for MC distribution sampling — the single source of
-# truth for both the key-matching pattern below and sampler.sample_tree_species_params().
+# truth for both the key-matching pattern below and sampler.sample_species_params().
 TREE_SPECIES_PARAM_FIELDS = ("wood_dens", "carbon", "root_to_shoot", "nitrogen")
 
 # Keys are prefixed with the catalog name ("tree_") rather than bare field names,

--- a/shamba/model/tree_params.py
+++ b/shamba/model/tree_params.py
@@ -1,9 +1,24 @@
-from typing import Dict, Any, Optional
+import re
+from typing import Dict, Any
 
 import numpy as np
 from marshmallow import Schema, fields, post_load
 
 from model.common import csv_handler
+
+# Per-species fields eligible for MC distribution sampling — the single source of
+# truth for both the key-matching pattern below and sampler.sample_tree_species_params().
+TREE_SPECIES_PARAM_FIELDS = ("wood_dens", "carbon", "root_to_shoot", "nitrogen")
+
+# Keys are prefixed with the catalog name ("tree_") rather than bare field names,
+# since some fields (e.g. root_to_shoot) also exist on other species catalogs
+# (crop_params.csv) with independently-numbered species codes — a bare key would
+# be ambiguous between "tree species 3" and "crop species 3".
+# Matches MC distribution keys for per-species tree parameter sampling, e.g.
+# "tree_wood_dens_sp2", "tree_carbon_sp1", "tree_nitrogen_sp3".
+TREE_SPECIES_DIST_KEY_PATTERN = re.compile(
+    rf"^tree_({'|'.join(TREE_SPECIES_PARAM_FIELDS)})_sp(\d+)$"
+)
 
 
 def load_tree_species_data(
@@ -141,21 +156,19 @@ def create(tree_params) -> TreeParamsData:
     return schema.load(params)  # type: ignore
 
 
-def from_species_index(index: int, species_data: Optional[Dict[int, Dict]] = None):
+def from_species_index(index: int, species_data: Dict[int, Dict]):
     """
     Construct TreeParams from its species code (Sc column in tree_params.csv).
 
     Args:
         index: species code to look up
         species_data: pre-loaded species data (as returned by
-            load_tree_species_data()), to avoid re-reading the csv from disk
-            once per cohort. If not given, loads it fresh.
+            load_tree_species_data()), loaded once per run by the caller.
 
     Raises:
         KeyError: if the species code isn't present in tree_params.csv
     """
     index = int(index)
-    species_data = species_data if species_data is not None else load_tree_species_data()
     if index not in species_data:
         raise KeyError(
             f"No tree species with code {index} found in tree_params.csv "
@@ -200,7 +213,7 @@ def save(tree_params: TreeParamsData, file="tree_params.csv"):
 
 
 def create_tree_params_from_species_index(
-    csv_input_data: Dict[str, Any], cohort_count: int
+    csv_input_data: Dict[str, Any], cohort_count: int, species_data: Dict[int, Dict]
 ):
     tree_params = []
 
@@ -208,7 +221,7 @@ def create_tree_params_from_species_index(
         key = f"species{i + 1}"
         try:
             species_index = int(csv_input_data[key].item())
-            tree_params.append(from_species_index(species_index))
+            tree_params.append(from_species_index(species_index, species_data=species_data))
         except KeyError:
             raise KeyError(f"Warning: Missing key '{key}' in input data.")
     return tree_params

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -28,6 +28,7 @@ import model.emit as Emit
 import model.soil_params as SoilParams
 import model.tree_growth as TreeGrowth
 import model.tree_model as TreeModel
+import model.tree_params as TreeParams
 from model import configuration
 from model.common.calculate_emissions import get_location, handle_intervention
 import model.common.constants as CONSTANTS
@@ -420,6 +421,25 @@ def main(n, arguments):
         + data_handler.validate_species_data(vector_input_data)
         + data_handler.validate_required_mgmt_keys(vector_input_data)
     )
+
+    # Load the three species-lookup catalogs once here, at the shared import/validate
+    # step, rather than lazily inside calculate_emissions.py. This ensures a malformed
+    # tree_params.csv/crop_params.csv/biomass_pool_params.csv is reported alongside the
+    # other input errors above, instead of surfacing as a mid-calculation crash.
+    tree_species_data = crop_species_data = pool_species_data = None
+    try:
+        tree_species_data = TreeParams.load_tree_species_data()
+    except ValueError as e:
+        validation_errors.append(str(e))
+    try:
+        crop_species_data = CropParams.load_crop_species_data()
+    except ValueError as e:
+        validation_errors.append(str(e))
+    try:
+        pool_species_data = TreeModel.load_biomass_pool_species_data()
+    except ValueError as e:
+        validation_errors.append(str(e))
+
     if validation_errors:
         raise ValueError("\n".join(validation_errors))
 
@@ -510,6 +530,9 @@ def main(n, arguments):
             allometry=allometric_keys,
             gwp=gwp,
             seed=arguments["seed"],
+            tree_species_data=tree_species_data,
+            crop_species_data=crop_species_data,
+            pool_species_data=pool_species_data,
         )
 
         mc_summary = summarise_mc_results(mc_results)
@@ -561,6 +584,9 @@ def main(n, arguments):
             gwp=gwp,
             create_forward_soil_model=ForwardSoilModel.create,
             create_inverse_soil_model=InverseSoilModel.create,
+            tree_species_data=tree_species_data,
+            crop_species_data=crop_species_data,
+            pool_species_data=pool_species_data,
         )
 
     # ----------

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -262,7 +262,9 @@ def get_repo_state() -> str:
         return "unknown (not running from a git checkout, or git is not available)"
 
 
-def write_run_metadata(output_path: str, soil_model_type: SoilModelType, repo_state: str) -> None:
+def write_run_metadata(
+    output_path: str, soil_model_type: SoilModelType, repo_state: str, monte_carlo: bool
+) -> None:
     """Write a small plain-text record of which soil model and code version a run used.
 
     Written for every run (deterministic or Monte Carlo) so the output directory
@@ -275,6 +277,7 @@ def write_run_metadata(output_path: str, soil_model_type: SoilModelType, repo_st
         f"Run timestamp : {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}",
         f"Soil model    : {soil_model_type.value}",
         f"Repo commit   : {repo_state}",
+        f"Monte Carlo   : {'yes — see mc_run_metadata.txt' if monte_carlo else 'no'}",
     ]
     with open(output_path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + "\n")
@@ -534,7 +537,9 @@ def main(n, arguments):
     os.makedirs(dir)
 
     repo_state = get_repo_state()
-    write_run_metadata(str(dir / "run_metadata.txt"), soil_model_type, repo_state)
+    write_run_metadata(
+        str(dir / "run_metadata.txt"), soil_model_type, repo_state, monte_carlo=bool(arguments["n-samples"])
+    )
 
     plot_name = str(dir / f"plot_{n + st}")
 

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -422,7 +422,7 @@ def main(n, arguments):
         + data_handler.validate_required_mgmt_keys(vector_input_data)
     )
 
-    # Load the three species-lookup catalogs once here, at the shared import/validate
+    # Load the three species-lookup tables once here, at the shared import/validate
     # step, rather than lazily inside calculate_emissions.py. This ensures a malformed
     # tree_params.csv/crop_params.csv/biomass_pool_params.csv is reported alongside the
     # other input errors above, instead of surfacing as a mid-calculation crash.

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -12,7 +12,9 @@ https://files.edinburgh-innovations.ed.ac.uk/ei-web/production/images/Small-hold
 import csv
 import os
 import shutil
+import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -35,6 +37,7 @@ import model.common.constants as CONSTANTS
 
 import model.soil_models.forward_soil_model as ForwardSoilModule
 import model.soil_models.inverse_soil_model as InverseSoilModule
+from model.soil_models.soil_model_types import SoilModelType
 from model.monte_carlo import distribution_handler
 from model.monte_carlo.runner import run_monte_carlo, summarise_mc_results, write_mc_summary_csv, write_mc_metadata
 
@@ -234,6 +237,47 @@ def save_crop_data(base_data, project_data, plot_name, model_type):
         elif model_type == "crop_params":
             CropParams.save(base, str(base_filename))
             CropParams.save(project, str(project_filename))
+
+
+def get_repo_state() -> str:
+    """Return the git commit SHAMBA ran from, for output provenance.
+
+    Falls back to a plain-language "unknown" note if this isn't a git checkout
+    or git isn't installed (e.g. inside some deployment images) — missing
+    provenance shouldn't fail a run.
+    """
+    repo_dir = os.path.dirname(os.path.abspath(__file__))
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repo_dir, stderr=subprocess.DEVNULL
+        ).decode().strip()
+        # Untracked files are included, Gitignored files (caches, scratch output) are 
+        # already excluded by git itself.
+        status = subprocess.check_output(
+            ["git", "status", "--porcelain"], cwd=repo_dir, stderr=subprocess.DEVNULL
+        ).decode()
+        dirty_note = " (dirty — uncommitted changes present)" if status.strip() else ""
+        return f"{commit}{dirty_note}"
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return "unknown (not running from a git checkout, or git is not available)"
+
+
+def write_run_metadata(output_path: str, soil_model_type: SoilModelType, repo_state: str) -> None:
+    """Write a small plain-text record of which soil model and code version a run used.
+
+    Written for every run (deterministic or Monte Carlo) so the output directory
+    is self-describing without needing to know which arguments the CLI was
+    invoked with, or which checkout produced it.
+    """
+    lines = [
+        "SHAMBA run metadata",
+        "=" * 40,
+        f"Run timestamp : {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}",
+        f"Soil model    : {soil_model_type.value}",
+        f"Repo commit   : {repo_state}",
+    ]
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
 
 
 def write_emissions_csv(output_dir, n, st, data):
@@ -440,6 +484,17 @@ def main(n, arguments):
     except ValueError as e:
         validation_errors.append(str(e))
 
+    # Load and validate the Monte Carlo distributions file, if supplied, so a
+    # malformed file is reported alongside other input errors, instead of
+    # surfacing as a mid-run crash.
+    distribution_dict = None
+    if arguments["n-samples"] and arguments["distribution-file-name"]:
+        distribution_file_path = os.path.join(configuration.INPUT_DIR, arguments["distribution-file-name"])
+        try:
+            distribution_dict = distribution_handler.load_distributions(distribution_file_path, vector_input_data)
+        except ValueError as e:
+            validation_errors.append(str(e))
+
     if validation_errors:
         raise ValueError("\n".join(validation_errors))
 
@@ -475,6 +530,9 @@ def main(n, arguments):
         shutil.rmtree(dir)
     os.makedirs(dir)
 
+    repo_state = get_repo_state()
+    write_run_metadata(str(dir / "run_metadata.txt"), soil_model_type, repo_state)
+
     plot_name = str(dir / f"plot_{n + st}")
 
     datasets = [
@@ -509,11 +567,6 @@ def main(n, arguments):
 
     if arguments["n-samples"]:
         n_samples = arguments["n-samples"]
-        if arguments["distribution-file-name"]:
-            distribution_file_path = os.path.join(configuration.INPUT_DIR, arguments["distribution-file-name"])
-            distribution_dict = distribution_handler.load_distributions(distribution_file_path, vector_input_data)
-        else:
-            distribution_dict = None
 
         mc_results = run_monte_carlo(
             base_input_dict=vector_input_data,
@@ -547,6 +600,8 @@ def main(n, arguments):
             output_path=str(dir / "mc_run_metadata.txt"),
             n_samples=n_samples,
             seed=arguments["seed"],
+            soil_model_type=soil_model_type,
+            repo_state=repo_state,
             soil_params=soil_params,
             climate=climate,
             distribution_dict=distribution_dict,

--- a/shamba/shamba_command_line.py
+++ b/shamba/shamba_command_line.py
@@ -359,6 +359,9 @@ def setup_project_directory(project_name, arguments):
     else:
         files_to_copy.append(arguments["input-file-name"])
 
+    if arguments["n-samples"] and arguments["distribution-file-name"]:
+        files_to_copy.append(arguments["distribution-file-name"])
+
     # Source directory (using an existing project as an example)
     source_dir = os.path.join(configuration.PROJECT_DIR, arguments["source-directory"])
 

--- a/shamba/tests/test_crop_emissions.py
+++ b/shamba/tests/test_crop_emissions.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from model import configuration
 from model.crop_model import get_crop_bases, get_crop_projects
+from model.crop_params import load_crop_species_data
 from model.common.data_handler import expand_single_row_data_input
 
 #-- Expected emissions arrays -- #
@@ -76,11 +77,14 @@ def test_crop_model(csv_input_file, expected_base_emissions, expected_project_em
     n_crop_base = sum(1 for i in range(1, 100) if f"crop_base_spp{i}" in input_data)
     n_crop_proj = sum(1 for i in range(1, 100) if f"crop_proj_spp{i}" in input_data)
 
+    species_data = load_crop_species_data()
     crop_base, _crop_par_base = get_crop_bases(
-        input_data=input_data, no_of_years=N_YEARS, start_index=1, end_index=n_crop_base
+        input_data=input_data, no_of_years=N_YEARS, start_index=1, end_index=n_crop_base,
+        species_data=species_data,
     )
     crop_project, _crop_par_project = get_crop_projects(
-        input_data=input_data, no_of_years=N_YEARS, start_index=1, end_index=n_crop_proj
+        input_data=input_data, no_of_years=N_YEARS, start_index=1, end_index=n_crop_proj,
+        species_data=species_data,
     )
 
     crop_base_emissions = Emit.create(

--- a/shamba/tests/test_distribution_handler.py
+++ b/shamba/tests/test_distribution_handler.py
@@ -128,6 +128,61 @@ def test_unknown_parameter_raises(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# RothC and species-lookup parameters are recognised without a base_input_dict entry
+# ---------------------------------------------------------------------------
+# These keys are routed by runner.py's _partition_distributions() to
+# sample_soil_model_params()/sample_species_params(), not looked up against
+# base_input_dict, so they must not be rejected as "not a recognised input
+# parameter" even though base_input_dict (the flat intervention-input dict)
+# has no matching key.
+
+def test_roth_c_parameter_recognised(tmp_path):
+    csv = write_csv(tmp_path,
+        "parameter,distribution,spread_lower,spread_upper\n"
+        "roth_c_temp_a1,normal,0.1,0.1\n"
+    )
+    specs = load_distributions(csv, BASE_DICT)
+    assert "roth_c_temp_a1" in specs
+
+
+def test_tree_species_parameter_recognised(tmp_path):
+    csv = write_csv(tmp_path,
+        "parameter,distribution,spread_lower,spread_upper\n"
+        "tree_wood_dens_sp1,normal,0.1,0.1\n"
+    )
+    specs = load_distributions(csv, BASE_DICT)
+    assert "tree_wood_dens_sp1" in specs
+
+
+def test_crop_species_parameter_recognised(tmp_path):
+    csv = write_csv(tmp_path,
+        "parameter,distribution,spread_lower,spread_upper\n"
+        "crop_slope_sp3,normal,0.1,0.1\n"
+    )
+    specs = load_distributions(csv, BASE_DICT)
+    assert "crop_slope_sp3" in specs
+
+
+def test_pool_species_parameter_recognised(tmp_path):
+    csv = write_csv(tmp_path,
+        "parameter,distribution,spread_lower,spread_upper\n"
+        "pool_turnover_sp2,normal,0.1,0.1\n"
+    )
+    specs = load_distributions(csv, BASE_DICT)
+    assert "pool_turnover_sp2" in specs
+
+
+def test_roth_c_parameter_still_validates_distribution_type(tmp_path):
+    """Recognising roth_c_*/species keys doesn't bypass the other row checks."""
+    csv = write_csv(tmp_path,
+        "parameter,distribution,spread_lower,spread_upper\n"
+        "roth_c_temp_a1,pareto,0.3,0.3\n"
+    )
+    with pytest.raises(ValueError, match="pareto"):
+        load_distributions(csv, BASE_DICT)
+
+
+# ---------------------------------------------------------------------------
 # Error: unsupported distribution
 # ---------------------------------------------------------------------------
 

--- a/shamba/tests/test_fire_emissions.py
+++ b/shamba/tests/test_fire_emissions.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from model import configuration
 from model.crop_model import get_crop_bases, get_crop_projects
+from model.crop_params import load_crop_species_data
 import model.common.constants as CONSTANTS
 from model.common.data_handler import expand_single_row_data_input
 
@@ -77,11 +78,14 @@ def test_crop_fire_model(csv_input_file, expected_base_emissions, expected_proje
     n_crop_base = sum(1 for i in range(1, 100) if f"crop_base_spp{i}" in input_data)
     n_crop_proj = sum(1 for i in range(1, 100) if f"crop_proj_spp{i}" in input_data)
 
+    species_data = load_crop_species_data()
     crop_base, _crop_par_base = get_crop_bases(
-        input_data=input_data, no_of_years=N_YEARS, start_index=1, end_index=n_crop_base
+        input_data=input_data, no_of_years=N_YEARS, start_index=1, end_index=n_crop_base,
+        species_data=species_data,
     )
     crop_project, _crop_par_project = get_crop_projects(
-        input_data=input_data, no_of_years=N_YEARS, start_index=1, end_index=n_crop_proj
+        input_data=input_data, no_of_years=N_YEARS, start_index=1, end_index=n_crop_proj,
+        species_data=species_data,
     )
 
     fire_base_emissions = Emit.fire_emit(

--- a/shamba/tests/test_integration_split_file.py
+++ b/shamba/tests/test_integration_split_file.py
@@ -27,6 +27,9 @@ import model.soil_models.inverse_soil_model as InverseSoilModule
 from model.soil_models.soil_model_types import SoilModelType
 import model.climate as Climate
 import model.soil_params as SoilParams
+import model.tree_params as TreeParams
+import model.tree_model as TreeModel
+import model.crop_params as CropParams
 
 
 FIXTURES_DIR = os.path.join(configuration.TESTS_DIR, "fixtures")
@@ -159,6 +162,9 @@ def test_split_file_full_run_matches_single_row(tmp_path, monkeypatch):
         allometry=ALLOMETRIC_KEYS,
         create_forward_soil_model=forward_model.create,
         create_inverse_soil_model=inverse_model.create,
+        tree_species_data=TreeParams.load_tree_species_data(),
+        crop_species_data=CropParams.load_crop_species_data(),
+        pool_species_data=TreeModel.load_biomass_pool_species_data(),
     )
 
     result_single = handle_intervention(intervention_input=single_row_dict, **common_kwargs)

--- a/shamba/tests/test_runner.py
+++ b/shamba/tests/test_runner.py
@@ -60,6 +60,18 @@ class FakeClimateData:
         self.evaporation_std = np.zeros(12)
 
 
+class FakeClimateDataWithUncertainty:
+    """Non-zero std, so sample_climate_params() actually draws distinct values
+    per sample instead of returning the mean every time (see FakeClimateData)."""
+    def __init__(self):
+        self.temperature = np.array([20.0] * 12)
+        self.rain = np.array([80.0] * 12)
+        self.evaporation = np.array([50.0] * 12)
+        self.temperature_std = np.full(12, 2.0)
+        self.rain_std = np.full(12, 5.0)
+        self.evaporation_std = np.full(12, 3.0)
+
+
 BASE_INPUT = {
     "temp": np.array([20.0] * 12),
     "rain": np.array([80.0] * 12),
@@ -155,6 +167,40 @@ def test_run_monte_carlo_deterministic_no_distributions():
                 np.asarray(subsequent[key]),
                 err_msg=f"Input '{key}' differs between samples despite zero uncertainty",
             )
+
+
+def test_run_monte_carlo_checkpointing_does_not_reuse_climate_across_batches():
+    """Regression test: each checkpoint batch must draw its own slice of
+    climate_samples."""
+    captured_climate = []
+
+    def capture(**kwargs):
+        captured_climate.append(kwargs["climate"])
+        return FIXED_RESULT
+
+    with patch("model.monte_carlo.runner.handle_intervention", side_effect=capture), \
+         patch("model.monte_carlo.runner.concurrent.futures.ProcessPoolExecutor", _InProcessExecutor):
+        run_monte_carlo(
+            base_input_dict=BASE_INPUT,
+            soil_params=FakeSoilParams(),
+            climate=FakeClimateDataWithUncertainty(),
+            n_samples=4,
+            create_forward_soil_model=fake_forward,
+            create_inverse_soil_model=fake_inverse,
+            n_proj_cohorts=1,
+            n_base_cohorts=1,
+            plot_index=0,
+            tree_species_data={},
+            crop_species_data={},
+            pool_species_data={},
+            seed=7,
+            checkpoint_every=2,
+        )
+
+    assert len(captured_climate) == 4
+    # Batch 2 (samples 2, 3) must not repeat batch 1's (samples 0, 1) draws.
+    assert not np.array_equal(captured_climate[2].temperature, captured_climate[0].temperature)
+    assert not np.array_equal(captured_climate[3].temperature, captured_climate[1].temperature)
 
 
 # ---------------------------------------------------------------------------

--- a/shamba/tests/test_runner.py
+++ b/shamba/tests/test_runner.py
@@ -13,7 +13,12 @@ import numpy as np
 import pytest
 from unittest.mock import patch, MagicMock
 
-from model.monte_carlo.runner import run_monte_carlo, summarise_mc_results, write_mc_summary_csv
+from model.monte_carlo.runner import (
+    run_monte_carlo,
+    summarise_mc_results,
+    write_mc_summary_csv,
+)
+from model.monte_carlo.distribution_handler import DistributionSpec
 
 
 class _InProcessExecutor:
@@ -201,6 +206,57 @@ def test_run_monte_carlo_checkpointing_does_not_reuse_climate_across_batches():
     # Batch 2 (samples 2, 3) must not repeat batch 1's (samples 0, 1) draws.
     assert not np.array_equal(captured_climate[2].temperature, captured_climate[0].temperature)
     assert not np.array_equal(captured_climate[3].temperature, captured_climate[1].temperature)
+
+
+
+# ---------------------------------------------------------------------------
+# Species-parameter sampling wiring (Part 1 Step 1d)
+# ---------------------------------------------------------------------------
+
+def test_run_monte_carlo_species_distribution_key_does_not_crash_and_perturbs_species():
+    """A tree_*_sp{N} distribution key must route to sample_species_params(), not
+    reach draw_samples() — which does a direct base_input_dict[key] lookup and
+    would raise a KeyError, since species-lookup keys were never part of the
+    flat intervention-input dict."""
+    tree_species_data = {
+        1: {
+            "species": 1, "name": "sp1", "wood_dens": 0.6, "carbon": 0.5,
+            "nitrogen": np.array([0.01, 0.01, 0.01, 0.01, 0.01]), "root_to_shoot": 0.26,
+        },
+    }
+    captured_tree_species = []
+
+    def capture(**kwargs):
+        captured_tree_species.append(kwargs["tree_species_data"])
+        return FIXED_RESULT
+
+    spec = DistributionSpec(
+        parameter="tree_wood_dens_sp1", distribution="uniform",
+        spread_lower=0.2, spread_upper=0.2, min_abs=None,
+    )
+
+    with patch("model.monte_carlo.runner.handle_intervention", side_effect=capture), \
+         patch("model.monte_carlo.runner.concurrent.futures.ProcessPoolExecutor", _InProcessExecutor):
+        run_monte_carlo(
+            base_input_dict=BASE_INPUT,
+            soil_params=FakeSoilParams(),
+            climate=FakeClimateData(),
+            n_samples=5,
+            create_forward_soil_model=fake_forward,
+            create_inverse_soil_model=fake_inverse,
+            n_proj_cohorts=1,
+            n_base_cohorts=1,
+            plot_index=0,
+            tree_species_data=tree_species_data,
+            crop_species_data={},
+            pool_species_data={},
+            distribution_dict={"tree_wood_dens_sp1": spec},
+            seed=3,
+        )
+
+    wood_dens_values = {round(float(t[1]["wood_dens"]), 8) for t in captured_tree_species}
+    assert len(wood_dens_values) > 1, "Expected spread across samples for the distributed species param"
+
 
 
 # ---------------------------------------------------------------------------

--- a/shamba/tests/test_runner.py
+++ b/shamba/tests/test_runner.py
@@ -110,6 +110,9 @@ def test_run_monte_carlo_returns_n_samples():
             n_proj_cohorts=1,
             n_base_cohorts=1,
             plot_index=0,
+            tree_species_data={},
+            crop_species_data={},
+            pool_species_data={},
             seed=0,
         )
     assert len(results) == 5
@@ -136,6 +139,9 @@ def test_run_monte_carlo_deterministic_no_distributions():
             n_proj_cohorts=1,
             n_base_cohorts=1,
             plot_index=0,
+            tree_species_data={},
+            crop_species_data={},
+            pool_species_data={},
             seed=42,
         )
 

--- a/shamba/tests/test_sampler.py
+++ b/shamba/tests/test_sampler.py
@@ -24,9 +24,11 @@ from model.monte_carlo.sampler import (
     draw_samples,
     sample_soil_params,
     sample_climate_params,
+    sample_soil_model_params,
     sample_model_params,
 )
 from model.emit import EmissionFactors
+from model.soil_models.soil_model_params import RothCParams, ExampleSoilModelParams
 
 
 # ---------------------------------------------------------------------------
@@ -380,6 +382,47 @@ def test_sample_climate_params_evap_clipped():
     rng = np.random.default_rng(6)
     samples = sample_climate_params(climate, n_samples=200, rng=rng)
     assert all(np.all(s.evaporation >= 0.0) for s in samples)
+
+
+# ---------------------------------------------------------------------------
+# sample_soil_model_params — one field perturbed
+# ---------------------------------------------------------------------------
+
+def test_sample_soil_model_params_perturbs_only_matching_field():
+    """A distribution on roth_c_temp_a1 perturbs temp_a1 only; other fields stay fixed."""
+    base = RothCParams()
+    specs = {"roth_c_temp_a1": make_spec("normal", 0.1, 0.1)}
+    rng = np.random.default_rng(1)
+    samples = sample_soil_model_params(base, distributions=specs, key_prefix="roth_c", n_samples=500, rng=rng)
+
+    temp_a1_vals = [s.temp_a1 for s in samples]
+    assert np.std(temp_a1_vals) > 0.0
+    assert np.mean(temp_a1_vals) == pytest.approx(base.temp_a1, rel=0.05)
+
+    for s in samples:
+        assert s.dpm_frac_crop == base.dpm_frac_crop
+        assert s.dpm_frac_tree == base.dpm_frac_tree
+        assert s.temp_a2 == base.temp_a2
+        assert s.temp_a3 == base.temp_a3
+        assert s.moisture_b_slope == base.moisture_b_slope
+        assert s.cover_c == base.cover_c
+
+
+def test_sample_soil_model_params_returns_same_type_as_base():
+    """Every sample is a RothCParams instance, not a plain dict."""
+    base = RothCParams()
+    rng = np.random.default_rng(2)
+    samples = sample_soil_model_params(base, distributions={}, key_prefix="roth_c", n_samples=5, rng=rng)
+    assert all(isinstance(s, RothCParams) for s in samples)
+
+
+def test_sample_soil_model_params_is_soil_model_agnostic():
+    """The sampler is generic over any soil model's NamedTuple, e.g. ExampleSoilModelParams."""
+    base = ExampleSoilModelParams()
+    rng = np.random.default_rng(3)
+    samples = sample_soil_model_params(base, distributions={}, key_prefix="example", n_samples=10, rng=rng)
+    assert len(samples) == 10
+    assert all(isinstance(s, ExampleSoilModelParams) for s in samples)
 
 
 # ---------------------------------------------------------------------------

--- a/shamba/tests/test_tree_emissions.py
+++ b/shamba/tests/test_tree_emissions.py
@@ -7,6 +7,8 @@ import model.tree_model as TreeModel
 import model.tree_params as TreeParams
 import model.tree_growth as TreeGrowth
 from model.common.data_handler import expand_single_row_data_input, validate_all_grouped_headers
+from model.monte_carlo.distribution_handler import DistributionSpec
+from model.monte_carlo.sampler import sample_species_params
 
 WL_N_COHORTS = 1
 WL_allometric_keys = ["chave dry", "chave dry"]
@@ -452,4 +454,124 @@ def test_validation_requires_per_cohort_thinning_when_second_cohort_present():
     missing_keys = [e for e in errors if "cohort2" in e]
     assert len(missing_keys) == 6, (
         f"Expected 6 missing-cohort-2 errors (one per thinning/mortality key), got: {missing_keys}"
+    )
+
+
+def _write_pool_params_csv(tmp_path, branch_al, stem_al):
+    """Minimal single-species biomass_pool_params.csv, branch/stem AL as given."""
+    path = tmp_path / "biomass_pool_params.csv"
+    path.write_text(
+        "Sc,pool,TO,AL,THf,DTf\n"
+        "1,leaf,1,0.1,1,1\n"
+        f"1,branch,0.05,{branch_al},0,0\n"
+        f"1,stem,0,{stem_al},0,0\n"
+        "1,croot,0,0,1,1\n"
+        "1,froot,0.8,0.1,1,1\n"
+    )
+    return str(path)
+
+
+def _wl_tree_par_and_growth():
+    """Species-1 TreeParams and TreeGrowth from the WL fixture, for pool-alloc tests
+    that don't care about the rest of the intervention input."""
+    file_path = os.path.join(configuration.TESTS_DIR, "fixtures", "WL_input.csv")
+    scalar_input_data, tree_size_data, _, _ = expand_single_row_data_input(file_path)
+    tree_species_data = TreeParams.load_tree_species_data()
+    tree_par = TreeParams.from_species_index(
+        int(scalar_input_data["base_species1"][0]), species_data=tree_species_data
+    )
+    growth_input = {
+        **scalar_input_data,
+        **tree_size_data,
+        "species1": scalar_input_data["proj_species1"],
+    }
+    growth = TreeGrowth.get_growth(
+        growth_input, "base_species1", tree_par, allometric_key="chave dry"
+    )
+    no_of_years = int(scalar_input_data["yrs_proj"].item())
+    stand_density = int(scalar_input_data["base_plant_dens1"][0])
+    return tree_par, growth, no_of_years, stand_density
+
+
+def test_load_biomass_pool_species_data_rejects_branch_stem_mismatch(tmp_path):
+    """Branch + stem 'AL' must sum to 1 (SHAMBA_ModelDescription_v1.2, Sec 4.3.2:
+    alstem/albranch are a split of total above-ground biomass)."""
+    bad_path = _write_pool_params_csv(tmp_path, branch_al=0.5, stem_al=0.6)
+    with pytest.raises(ValueError, match=r"branch and stem 'AL'"):
+        TreeModel.load_biomass_pool_species_data(filename=bad_path)
+
+
+def test_load_biomass_pool_species_data_accepts_branch_stem_summing_to_one(tmp_path):
+    good_path = _write_pool_params_csv(tmp_path, branch_al=0.31, stem_al=0.69)
+    species_data = TreeModel.load_biomass_pool_species_data(filename=good_path)
+    assert species_data[1]["alloc"][1] == pytest.approx(0.31)
+    assert species_data[1]["alloc"][2] == pytest.approx(0.69)
+
+
+def test_from_defaults_derives_branch_alloc_from_stem():
+    """from_defaults() must derive branch = 1 - stem itself, not just trust a
+    validated catalog value — this is what keeps the identity true once MC
+    sampling can perturb stem independently of whatever branch happened to be."""
+    tree_par, growth, no_of_years, stand_density = _wl_tree_par_and_growth()
+    pool_species_data = TreeModel.load_biomass_pool_species_data()
+
+    # Deliberately inconsistent branch value (would fail load-time validation
+    # if it came from a real CSV) — proves from_defaults() ignores it and
+    # derives branch from stem regardless of pool_species_data.
+    tampered = {k: dict(v) for k, v in pool_species_data.items()}
+    tampered[tree_par.species]["alloc"] = np.array(
+        [0.1, 0.99, 0.69, 0.0, 0.1]
+    )  # leaf, branch(fake), stem, croot, froot
+
+    tree = TreeModel.from_defaults(
+        tree_params=tree_par,
+        tree_growth=growth,
+        no_of_years=no_of_years,
+        stand_density=stand_density,
+        pool_species_data=tampered,
+    )
+    assert tree.alloc[1] == pytest.approx(1 - tree.alloc[2])
+    assert tree.alloc[1] == pytest.approx(0.31)  # 1 - 0.69, not the fake 0.99
+
+
+def test_from_defaults_derives_branch_alloc_after_species_param_sampling():
+    """pool_alloc_sp{N} sampling perturbs stem independently of branch; the
+    branch+stem=1 identity must still hold on every sampled draw."""
+    tree_par, growth, no_of_years, stand_density = _wl_tree_par_and_growth()
+    pool_species_data = TreeModel.load_biomass_pool_species_data()
+
+    rng = np.random.default_rng(42)
+    spec = DistributionSpec(
+        parameter=f"pool_alloc_sp{tree_par.species}",
+        distribution="uniform",
+        spread_lower=0.2,
+        spread_upper=0.2,
+        min_abs=None,
+    )
+    samples = sample_species_params(
+        base_params=pool_species_data,
+        distributions={f"pool_alloc_sp{tree_par.species}": spec},
+        param_fields=TreeModel.BIOMASS_POOL_PARAM_FIELDS,
+        key_prefix="pool",
+        n_samples=10,
+        rng=rng,
+    )
+
+    base_stem = pool_species_data[tree_par.species]["alloc"][2]
+    saw_perturbed_stem = False
+    for sample in samples:
+        tree = TreeModel.from_defaults(
+            tree_params=tree_par,
+            tree_growth=growth,
+            no_of_years=no_of_years,
+            stand_density=stand_density,
+            pool_species_data=sample,
+        )
+        assert tree.alloc[1] == pytest.approx(1 - tree.alloc[2])
+        assert tree.alloc[1] + tree.alloc[2] == pytest.approx(1.0)
+        if tree.alloc[2] != pytest.approx(base_stem):
+            saw_perturbed_stem = True
+
+    assert saw_perturbed_stem, (
+        "Expected pool_alloc_sp sampling to actually perturb stem across samples"
     )

--- a/shamba/tests/test_tree_emissions.py
+++ b/shamba/tests/test_tree_emissions.py
@@ -222,8 +222,15 @@ def test_tree_model(csv_input_file, N_COHORTS, allometric_keys, expected_base_em
     burn_off_base = bool(np.any(mgmt_input_data["fire_off_base"]))
     burn_off_project = bool(np.any(mgmt_input_data["fire_off_proj"]))
 
-    tree_par_base = TreeParams.from_species_index(int(scalar_input_data["base_species1"][0]))
-    tree_params_1 = TreeParams.from_species_index(int(scalar_input_data["proj_species1"][0]))
+    tree_species_data = TreeParams.load_tree_species_data()
+    pool_species_data = TreeModel.load_biomass_pool_species_data()
+
+    tree_par_base = TreeParams.from_species_index(
+        int(scalar_input_data["base_species1"][0]), species_data=tree_species_data
+    )
+    tree_params_1 = TreeParams.from_species_index(
+        int(scalar_input_data["proj_species1"][0]), species_data=tree_species_data
+    )
 
     # growth_input merges scalars, tree size, and an alias so create_tree_params_from_species_index
     # can find "species1" (its expected key for the first project cohort)
@@ -262,9 +269,12 @@ def test_tree_model(csv_input_file, N_COHORTS, allometric_keys, expected_base_em
         mortality=mortality_base,
         mortality_fraction=mortality_fraction_left_base,
         no_of_years=N_YEARS,
+        pool_species_data=pool_species_data,
     )
 
-    tree_params = TreeParams.create_tree_params_from_species_index(growth_input, N_COHORTS)
+    tree_params = TreeParams.create_tree_params_from_species_index(
+        growth_input, N_COHORTS, species_data=tree_species_data
+    )
     tree_growths = TreeGrowth.create_tree_growths(growth_input, tree_params, allometric_keys, N_COHORTS)
 
     thinnings_project = [mgmt_input_data["thin_proj_cohort1"]]
@@ -293,6 +303,7 @@ def test_tree_model(csv_input_file, N_COHORTS, allometric_keys, expected_base_em
         no_of_years=N_YEARS,
         cohort_count=N_COHORTS,
         type="proj",
+        pool_species_data=pool_species_data,
     )
 
     tree_base_emissions = Emit.create(
@@ -326,7 +337,11 @@ def test_create_tree_projects_uses_per_cohort_thinning():
         "proj_plant_yr2": scalar_input_data["proj_plant_yr1"],
         "proj_plant_dens2": scalar_input_data["proj_plant_dens1"],
     }
-    tree_params = TreeParams.create_tree_params_from_species_index(growth_input, 2)
+    tree_species_data = TreeParams.load_tree_species_data()
+    pool_species_data = TreeModel.load_biomass_pool_species_data()
+    tree_params = TreeParams.create_tree_params_from_species_index(
+        growth_input, 2, species_data=tree_species_data
+    )
     tree_growths = TreeGrowth.create_tree_growths(
         growth_input, tree_params, ["chave dry", "chave dry", "chave dry"], 2
     )
@@ -352,6 +367,7 @@ def test_create_tree_projects_uses_per_cohort_thinning():
         no_of_years=N_YEARS,
         cohort_count=2,
         type="proj",
+        pool_species_data=pool_species_data,
     )
 
     assert tree_projects[0].thinning[0] != tree_projects[1].thinning[0], (
@@ -378,7 +394,11 @@ def test_create_tree_baselines_uses_per_cohort_thinning():
         "proj_plant_yr2": scalar_input_data["base_plant_yr1"],
         "proj_plant_dens2": scalar_input_data["base_plant_dens1"],
     }
-    tree_params = TreeParams.create_tree_params_from_species_index(growth_input, 2)
+    tree_species_data = TreeParams.load_tree_species_data()
+    pool_species_data = TreeModel.load_biomass_pool_species_data()
+    tree_params = TreeParams.create_tree_params_from_species_index(
+        growth_input, 2, species_data=tree_species_data
+    )
     tree_growths = TreeGrowth.create_tree_growths(
         growth_input, tree_params, ["chave dry", "chave dry", "chave dry"], 2
     )
@@ -404,6 +424,7 @@ def test_create_tree_baselines_uses_per_cohort_thinning():
         no_of_years=N_YEARS,
         cohort_count=2,
         type="proj",
+        pool_species_data=pool_species_data,
     )
 
     assert tree_baselines[0].thinning[0] != tree_baselines[1].thinning[0], (

--- a/shamba/tests/test_tree_emissions.py
+++ b/shamba/tests/test_tree_emissions.py
@@ -510,8 +510,8 @@ def test_load_biomass_pool_species_data_accepts_branch_stem_summing_to_one(tmp_p
 
 def test_from_defaults_derives_branch_alloc_from_stem():
     """from_defaults() must derive branch = 1 - stem itself, not just trust a
-    validated catalog value — this is what keeps the identity true once MC
-    sampling can perturb stem independently of whatever branch happened to be."""
+    validated species-lookup value — this is what keeps the identity true once
+    MC sampling can perturb stem independently of whatever branch happened to be."""
     tree_par, growth, no_of_years, stand_density = _wl_tree_par_and_growth()
     pool_species_data = TreeModel.load_biomass_pool_species_data()
 


### PR DESCRIPTION
## Summary

### Goals
- Better handling of three "species-lookup" input csvs to allow Monte-Carlo sampling:
  - tree params by species (N and C content, wood density, R:S), 
  - crop params (biomass ratios, N and C content) 
  - (tree) biomass pool params by species (turnover, allocation, thinning fraction left in field, mortality fraction left in field)
- Exposure of RothC model params to allow Monte-Carlo sampling.

### Implications
- Species-lookup csvs are now validated alongside other input data, consistent with intended pipeline.
- Monte-Carlo distributions csv can now include RothC, tree, crop and biomass pool data, indicated by specific prefixes. These are sampled during a Monte-Carlo run. User guidance on creating a distributions file is not yet comprehensive.
- The difference between parameters assigned to tree *species* and to tree *cohorts* is important, and a bug fix has clarified the prioritisation between them in one case (see below). User guidance needed on this, some included in `io_handler`.
- Improved metadata outputs.

## Main changes
- Species-lookup catalogs (tree/crop/biomass-pool) now loaded and validated once at import time instead of re-loaded inside `calculate_emissions.py` for each cohort. Removed the option for `species_data = None` + import inside relevant in-model functions: the data *must* be loaded at the start.
- Existing `sample_species_params()` generalised from tree-only to tree/crop/biomass-pool, wired into `run_monte_carlo()` via a new `_partition_distributions()` prefix router
- New `RothCParams`/`SoilModelParams` types so that RothC's rate-modifier (a, b, c) and DPM/RPM constants can be overridden and sampled, generalised via `sample_soil_model_params()`. The handling of `SoilModelParams` is a generic approach (to include different soil models), but the Monte-Carlo layer is hardcoded to RothC (would need to include `soil_model_type` in MC function calls to make this layer generic).
- `load_distributions()` recognises `roth_c_*`/`tree_*_sp{N}`/`crop_*_sp{N}`/`pool_*_sp{N}` keys instead of rejecting them
- New `run_metadata.txt` and `mc_run_metadata.txt` recording soil model type and git commit SHAMBA ran from

## Bug fixes
- Leaf/coarse-root/fine-root thinning & mortality fractions were hardcoded to 1 instead of read from `biomass_pool_params.csv` or the main intervention input file. Now: *if* they are present, *cohort* specific values from the main input file take precedence over *species* specific values in `biomass_pool_params.csv`.
- [`dev` only] Checkpointed MC runs reused batch 1's climate draws for every subsequent batch (`checkpoint_every > 0`, >1 batch)
- Branch + stem allocation wasn't validated/forced to sum to 1
- [`dev` only] Distributions CSV wasn't copied to the project `input/` folder

## Open items noted but not resolved
- distributions guidance needed, including that the file is allowed to contain data that then goes unused, such as soil model params for a soil model the user did not choose - this is one reason for metadata outputs that record what was actually applied
- species-vs-cohort precedence for leaf/croot/froot fractions flagged as needing further clarification
- whilst handling of `SoilModelParams` is a generic approach (to include different soil models), the Monte-Carlo layer is currently hardcoded to RothC (would need to include `soil_model_type` in MC function calls).